### PR TITLE
feat(scaffolding): initial repo structure (README, CHANGELOG, Makefile, LICENSE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial repository scaffolding (issue #4): README placeholder, CHANGELOG, Makefile skeleton, LICENSE, `.gitignore`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 BJ Baker <brian@waveeng.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+# beget — build targets will be added in issue #7

--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/install.sh | bash
 
 `install.sh` is produced by Phase 1. It does not exist yet.
 
-## Platform support
+## Prerequisites
+
+_Stub — detailed prerequisites will be documented as stories land._
+
+- A supported Linux distribution (see [Supported Platforms](#supported-platforms))
+- `git`, `curl`, and `bash` available on the target host
+- Network access to GitHub for fetching this repo and its dependencies
+
+## Supported Platforms
 
 - Ubuntu 24.04 LTS+
 - RHEL 9+ and family (Fedora current, Rocky Linux 9+, AlmaLinux 9+)


### PR DESCRIPTION
## Summary

S1.1 from wave-1a — establish the baseline files that future wave stories depend on (Makefile targets in #7, `lib/` consumers in #5, install flow in #6, etc.).

## Changes

- `README.md` — added `## Prerequisites` stub and renamed `## Platform support` → `## Supported Platforms` to match AC wording. Preserved existing disclaimer, one-liner, and Dev Spec link.
- `CHANGELOG.md` — new; Keep a Changelog 1.0.0 format with initial `## [Unreleased]` / `### Added` entry.
- `Makefile` — new; bare header comment only (`# beget — build targets will be added in issue #7`). Targets land in S1.4.
- `LICENSE` — new; MIT, Copyright (c) 2026 BJ Baker <brian@waveeng.com>.

`.gitignore` was intentionally NOT touched — it already satisfies the secret-prevention AC from the chore/44 merge, so no-churn policy applied.

## Test Plan

- Manual visual verification of all 4 files against AC bullets (done by executing agent + parent review + code-reviewer subagent).
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` → 0 findings.
- No automated tests in this story per spec — IT-02 (`shfmt --diff`) applies to future shell scripts; this PR has no shell.
- Fresh clone + `cat README.md CHANGELOG.md LICENSE Makefile` renders the expected content.

## Linked Issues

Closes #4