### PR TITLE
feat(platform): OS detection + package manager abstraction

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/bats"]
+	path = tests/bats
+	url = https://github.com/bats-core/bats-core

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,21 @@
-# beget — build targets will be added in issue #7
+# beget — build targets (additional targets will be added in issue #7)
+
+SHELL := /bin/bash
+
+.PHONY: help bootstrap-test-deps lint test-unit
+
+help:
+	@echo "beget — available targets:"
+	@echo "  bootstrap-test-deps  initialize the bats-core git submodule"
+	@echo "  lint                 run shellcheck on lib/*.sh"
+	@echo "  test-unit            run bats-core unit tests"
+
+# Ensure the bats-core submodule is checked out before running the test suite.
+bootstrap-test-deps:
+	git submodule update --init --recursive tests/bats
+
+lint:
+	shellcheck lib/*.sh
+
+test-unit: bootstrap-test-deps
+	tests/bats/bin/bats tests/unit

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# lib/platform.sh — OS detection and package manager abstraction
+#
+# Sourced library. Do NOT set -euo pipefail globally here — a library must
+# not alter the caller's shell options. Individual functions use `local`
+# variables and explicit return codes.
+#
+# Public functions:
+#   source_os_release          — populate OS_ID and OS_MAJOR_VERSION
+#   pkg_install <pkg>...       — install packages via apt-get or dnf
+#   pkg_repo_add <url> <keyring_url> <name>
+#                              — register an apt or yum repo
+#   is_gnome                   — return 0 if running under GNOME
+#   die_if_unsupported_os      — abort if OS is not Ubuntu 24.04 or Rocky 9
+#
+# Test seams (env-var overrides, default shown):
+#   OS_RELEASE_FILE  — /etc/os-release
+#   APT_SOURCES_DIR  — /etc/apt/sources.list.d
+#   YUM_REPOS_DIR    — /etc/yum.repos.d
+
+# Emit an error and exit non-zero. Used for clean aborts.
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+# Read /etc/os-release (or OS_RELEASE_FILE override) and export OS_ID +
+# OS_MAJOR_VERSION. Uses a subshell to avoid leaking other variables the
+# file may define.
+source_os_release() {
+    local os_release_file="${OS_RELEASE_FILE:-/etc/os-release}"
+    if [[ ! -r "$os_release_file" ]]; then
+        die "cannot read os-release file: $os_release_file"
+    fi
+
+    local id version_id major
+    # shellcheck disable=SC1090
+    id=$(. "$os_release_file" && printf '%s' "${ID:-}")
+    # shellcheck disable=SC1090
+    version_id=$(. "$os_release_file" && printf '%s' "${VERSION_ID:-}")
+
+    if [[ -z "$id" ]]; then
+        die "os-release missing ID field"
+    fi
+
+    # Extract leading numeric component of VERSION_ID (e.g. "24.04" -> "24",
+    # "9" -> "9", "9.3" -> "9"). If empty, leave OS_MAJOR_VERSION empty.
+    major="${version_id%%.*}"
+
+    export OS_ID="$id"
+    export OS_MAJOR_VERSION="$major"
+}
+
+# Install one or more packages using the native package manager.
+# Dispatches based on OS_ID (populated by source_os_release).
+pkg_install() {
+    if [[ $# -eq 0 ]]; then
+        die "pkg_install: no packages specified"
+    fi
+
+    if [[ -z "${OS_ID:-}" ]]; then
+        source_os_release
+    fi
+
+    case "$OS_ID" in
+        ubuntu|debian)
+            sudo apt-get install -y "$@"
+            ;;
+        rocky|rhel|centos|almalinux|fedora)
+            sudo dnf install -y "$@"
+            ;;
+        *)
+            die "pkg_install: unsupported OS_ID: $OS_ID"
+            ;;
+    esac
+}
+
+# Register an apt or yum repository.
+#   $1 — repo URL (apt: deb-line URL; yum: .repo file URL or base URL)
+#   $2 — keyring URL (apt: armored GPG; yum: RPM-GPG key URL)
+#   $3 — short name (used to derive the filename)
+pkg_repo_add() {
+    if [[ $# -lt 3 ]]; then
+        die "pkg_repo_add: usage: pkg_repo_add <url> <keyring_url> <name>"
+    fi
+
+    local url="$1"
+    local keyring_url="$2"
+    local name="$3"
+
+    if [[ -z "${OS_ID:-}" ]]; then
+        source_os_release
+    fi
+
+    local apt_dir="${APT_SOURCES_DIR:-/etc/apt/sources.list.d}"
+    local yum_dir="${YUM_REPOS_DIR:-/etc/yum.repos.d}"
+
+    case "$OS_ID" in
+        ubuntu|debian)
+            local keyring_path="/usr/share/keyrings/${name}.gpg"
+            local list_path="${apt_dir}/${name}.list"
+            # Fetch keyring separately: a sourced library can't set -o pipefail,
+            # so curl|gpg would silently swallow a curl failure and write an
+            # empty keyring. Fail fast instead.
+            local key_bytes
+            key_bytes=$(curl -fsSL "$keyring_url") \
+                || die "pkg_repo_add: failed to fetch keyring: $keyring_url"
+            printf '%s' "$key_bytes" | sudo gpg --dearmor -o "$keyring_path"
+            printf 'deb [signed-by=%s] %s\n' "$keyring_path" "$url" \
+                | sudo tee "$list_path" >/dev/null
+            ;;
+        rocky|rhel|centos|almalinux|fedora)
+            local repo_path="${yum_dir}/${name}.repo"
+            sudo curl -fsSL -o "$repo_path" "$url"
+            sudo rpm --import "$keyring_url"
+            ;;
+        *)
+            die "pkg_repo_add: unsupported OS_ID: $OS_ID"
+            ;;
+    esac
+}
+
+# Return 0 if running under a GNOME desktop session, 1 otherwise.
+# Heuristic: the string "GNOME" appears (case-insensitive) in
+# XDG_CURRENT_DESKTOP.
+is_gnome() {
+    local desktop="${XDG_CURRENT_DESKTOP:-}"
+    if [[ "${desktop,,}" == *gnome* ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Abort with a clear message unless the detected OS is in the supported set.
+# Supported: Ubuntu 24.04, Rocky 9.
+die_if_unsupported_os() {
+    if [[ -z "${OS_ID:-}" || -z "${OS_MAJOR_VERSION:-}" ]]; then
+        source_os_release
+    fi
+
+    case "${OS_ID}:${OS_MAJOR_VERSION}" in
+        ubuntu:24)
+            return 0
+            ;;
+        rocky:9)
+            return 0
+            ;;
+        *)
+            die "unsupported OS: ${OS_ID} ${OS_MAJOR_VERSION} (supported: Ubuntu 24.04, Rocky 9)"
+            ;;
+    esac
+}

--- a/tests/helpers/mocks.sh
+++ b/tests/helpers/mocks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# tests/helpers/mocks.sh — test helpers for platform.sh
+#
+# Provides make_os_release() to write a mock /etc/os-release file into a
+# temp dir and point OS_RELEASE_FILE at it.
+
+# make_os_release <id> <version_id> [pretty_name]
+# Writes a minimal os-release file to "$BATS_TEST_TMPDIR/os-release" and
+# exports OS_RELEASE_FILE to that path.
+make_os_release() {
+    local id="$1"
+    local version_id="$2"
+    local pretty_name="${3:-${id} ${version_id}}"
+
+    local tmpdir="${BATS_TEST_TMPDIR:-${TMPDIR:-/tmp}}"
+    local path="${tmpdir}/os-release"
+
+    cat >"$path" <<EOF
+NAME="${pretty_name}"
+ID=${id}
+VERSION_ID="${version_id}"
+PRETTY_NAME="${pretty_name}"
+EOF
+
+    export OS_RELEASE_FILE="$path"
+}
+
+# reset_os_env — clear OS-related env so each test starts fresh.
+reset_os_env() {
+    unset OS_ID OS_MAJOR_VERSION OS_RELEASE_FILE
+}

--- a/tests/unit/platform.bats
+++ b/tests/unit/platform.bats
@@ -1,0 +1,220 @@
+#!/usr/bin/env bats
+# tests/unit/platform.bats — unit tests for lib/platform.sh
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+    reset_os_env
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/lib/platform.sh"
+}
+
+teardown() {
+    reset_os_env
+}
+
+@test "source_os_release: Ubuntu 24.04 → OS_ID=ubuntu, OS_MAJOR_VERSION=24" {
+    make_os_release "ubuntu" "24.04" "Ubuntu 24.04 LTS"
+    source_os_release
+    [ "$OS_ID" = "ubuntu" ]
+    [ "$OS_MAJOR_VERSION" = "24" ]
+}
+
+@test "source_os_release: Rocky 9 → OS_ID=rocky, OS_MAJOR_VERSION=9" {
+    make_os_release "rocky" "9.3" "Rocky Linux 9.3"
+    source_os_release
+    [ "$OS_ID" = "rocky" ]
+    [ "$OS_MAJOR_VERSION" = "9" ]
+}
+
+@test "source_os_release: Rocky 9 with unquoted version_id" {
+    # Some os-release files have VERSION_ID=9 without decimal
+    cat >"$BATS_TEST_TMPDIR/os-release" <<EOF
+NAME="Rocky Linux"
+ID=rocky
+VERSION_ID="9"
+EOF
+    export OS_RELEASE_FILE="$BATS_TEST_TMPDIR/os-release"
+    source_os_release
+    [ "$OS_ID" = "rocky" ]
+    [ "$OS_MAJOR_VERSION" = "9" ]
+}
+
+@test "source_os_release: missing file aborts" {
+    export OS_RELEASE_FILE="/nonexistent/path/os-release"
+    run source_os_release
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"cannot read os-release"* ]]
+}
+
+@test "pkg_install: no args aborts" {
+    make_os_release "ubuntu" "24.04"
+    run pkg_install
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no packages specified"* ]]
+}
+
+@test "pkg_install: Ubuntu produces apt-get command" {
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+    # Stub sudo to emit one arg per line so argv boundaries are asserted.
+    sudo() { for a in "$@"; do printf 'ARG:%s\n' "$a"; done; }
+    export -f sudo
+    run pkg_install foo bar
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ARG:apt-get"* ]]
+    [[ "$output" == *"ARG:install"* ]]
+    [[ "$output" == *"ARG:-y"* ]]
+    [[ "$output" == *"ARG:foo"* ]]
+    [[ "$output" == *"ARG:bar"* ]]
+}
+
+@test "pkg_install: Rocky produces dnf command" {
+    make_os_release "rocky" "9.3"
+    source_os_release
+    sudo() { for a in "$@"; do printf 'ARG:%s\n' "$a"; done; }
+    export -f sudo
+    run pkg_install foo bar
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ARG:dnf"* ]]
+    [[ "$output" == *"ARG:install"* ]]
+    [[ "$output" == *"ARG:-y"* ]]
+    [[ "$output" == *"ARG:foo"* ]]
+    [[ "$output" == *"ARG:bar"* ]]
+}
+
+@test "pkg_install: unsupported OS aborts" {
+    make_os_release "arch" "rolling"
+    source_os_release
+    run pkg_install foo
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS_ID: arch"* ]]
+}
+
+@test "die_if_unsupported_os: Ubuntu 24.04 passes" {
+    make_os_release "ubuntu" "24.04"
+    run die_if_unsupported_os
+    [ "$status" -eq 0 ]
+}
+
+@test "die_if_unsupported_os: Rocky 9 passes" {
+    make_os_release "rocky" "9.3"
+    run die_if_unsupported_os
+    [ "$status" -eq 0 ]
+}
+
+@test "die_if_unsupported_os: Debian 11 aborts non-zero" {
+    make_os_release "debian" "11"
+    run die_if_unsupported_os
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS"* ]]
+    [[ "$output" == *"debian"* ]]
+}
+
+@test "die_if_unsupported_os: Ubuntu 22.04 (wrong major) aborts non-zero" {
+    make_os_release "ubuntu" "22.04"
+    run die_if_unsupported_os
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS"* ]]
+}
+
+@test "is_gnome: matches GNOME in XDG_CURRENT_DESKTOP" {
+    XDG_CURRENT_DESKTOP="GNOME" run is_gnome
+    [ "$status" -eq 0 ]
+}
+
+@test "is_gnome: matches case-insensitive gnome" {
+    XDG_CURRENT_DESKTOP="ubuntu:GNOME" run is_gnome
+    [ "$status" -eq 0 ]
+}
+
+@test "is_gnome: returns 1 when XDG_CURRENT_DESKTOP empty" {
+    unset XDG_CURRENT_DESKTOP
+    run is_gnome
+    [ "$status" -eq 1 ]
+}
+
+@test "is_gnome: returns 1 for KDE" {
+    XDG_CURRENT_DESKTOP="KDE" run is_gnome
+    [ "$status" -eq 1 ]
+}
+
+@test "pkg_repo_add: missing args aborts" {
+    make_os_release "ubuntu" "24.04"
+    run pkg_repo_add
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"usage"* ]]
+}
+
+@test "pkg_repo_add: Ubuntu writes .list under APT_SOURCES_DIR" {
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+    export APT_SOURCES_DIR="$BATS_TEST_TMPDIR/apt"
+    mkdir -p "$APT_SOURCES_DIR"
+    # Stub curl, sudo, gpg, tee so nothing touches the system.
+    curl() { printf 'armored-key-bytes'; }
+    gpg() {
+        # Parse `gpg --dearmor -o <path>` and write a placeholder there.
+        local out=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -o) out="$2"; shift 2;;
+                *)  shift;;
+            esac
+        done
+        cat >/dev/null
+        [[ -n "$out" ]] && : >"$out"
+    }
+    tee() { cat >"$1"; }
+    sudo() { "$@"; }
+    export -f curl gpg tee sudo
+    run pkg_repo_add "https://example.com/apt stable main" \
+        "https://example.com/key.asc" "example"
+    [ "$status" -eq 0 ]
+    [ -f "$APT_SOURCES_DIR/example.list" ]
+    grep -q "signed-by=/usr/share/keyrings/example.gpg" "$APT_SOURCES_DIR/example.list"
+    grep -q "https://example.com/apt stable main" "$APT_SOURCES_DIR/example.list"
+}
+
+@test "pkg_repo_add: Ubuntu aborts when keyring fetch fails" {
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+    export APT_SOURCES_DIR="$BATS_TEST_TMPDIR/apt"
+    mkdir -p "$APT_SOURCES_DIR"
+    # Stub curl to fail (simulating a 404 or network error).
+    curl() { return 22; }
+    sudo() { "$@"; }
+    export -f curl sudo
+    run pkg_repo_add "https://example.com/apt stable main" \
+        "https://example.com/key.asc" "example"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"failed to fetch keyring"* ]]
+    [ ! -f "$APT_SOURCES_DIR/example.list" ]
+}
+
+@test "pkg_repo_add: Rocky writes .repo under YUM_REPOS_DIR" {
+    make_os_release "rocky" "9.3"
+    source_os_release
+    export YUM_REPOS_DIR="$BATS_TEST_TMPDIR/yum"
+    mkdir -p "$YUM_REPOS_DIR"
+    # Stub curl to write the target path (-o path url), sudo to passthru, rpm to noop.
+    curl() {
+        local out=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -o) out="$2"; shift 2;;
+                *)  shift;;
+            esac
+        done
+        printf '[example]\nname=example\nbaseurl=https://example.com/rocky/9\n' >"$out"
+    }
+    rpm() { :; }
+    sudo() { "$@"; }
+    export -f curl rpm sudo
+    run pkg_repo_add "https://example.com/example.repo" \
+        "https://example.com/RPM-GPG-KEY-example" "example"
+    [ "$status" -eq 0 ]
+    [ -f "$YUM_REPOS_DIR/example.repo" ]
+    grep -q "baseurl=https://example.com/rocky/9" "$YUM_REPOS_DIR/example.repo"
+}


### PR DESCRIPTION
## Summary

Implements S1.2 — a sourced bash library (`lib/platform.sh`) providing OS detection and package-manager abstraction primitives used by later bootstrap stories. Adds the test infrastructure (`bats-core` submodule, Makefile targets) the rest of Phase 1 needs.

## Changes

- **`lib/platform.sh`** — 5 public functions: `source_os_release`, `pkg_install`, `pkg_repo_add`, `is_gnome`, `die_if_unsupported_os`, plus private `die()` helper.
- **Test seams** — `OS_RELEASE_FILE`, `APT_SOURCES_DIR`, `YUM_REPOS_DIR` env-var overrides let tests exercise real code paths without touching the host.
- **Library etiquette** — no global `set -euo pipefail` (sourced, must not alter caller's shell options); all functions use `local`; `source_os_release` parses `/etc/os-release` in a subshell to avoid variable leakage.
- **Safety fix** — `pkg_repo_add` captures curl output before piping to `gpg --dearmor` so a keyring fetch failure aborts loudly instead of silently writing a zero-byte keyring.
- **`tests/bats`** — git submodule pinned to `bats-core/bats-core` upstream.
- **`tests/unit/platform.bats`** — 20 tests covering all AC bullets + edge cases (unquoted VERSION_ID, curl-fail regression, wrong major version, KDE vs GNOME).
- **`tests/helpers/mocks.sh`** — `make_os_release` helper writes mock os-release files under `$BATS_TEST_TMPDIR`.
- **`Makefile`** — adds `help`, `bootstrap-test-deps` (submodule init), `lint` (shellcheck), `test-unit` (bats) targets with proper `.PHONY` and dependencies.

## Linked Issues

Closes #5

## Test Plan

- [x] `make lint` — shellcheck passes clean on `lib/*.sh`
- [x] `make bootstrap-test-deps` — bats-core submodule initialized from fresh clone
- [x] `make test-unit` — 20/20 bats tests pass
- [x] Trivy dependency scan — 0 HIGH/CRITICAL
- [x] Code reviewer found curl|gpg pipe swallowed errors — fixed + regression test added
- [x] Argv-preservation strengthened in `pkg_install` tests (one line per arg, delimited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)