### PR TITLE
chore: ignore entire .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,6 @@ tests/results/
 *.out
 
 # Agent session-local / runtime state
-.claude/status/
-.claude/context-states/
-.claude/crystallizer.log
+.claude/
 .status-panel.html
 .wtf/


### PR DESCRIPTION
## Summary

Collapse `.claude/status/`, `.claude/context-states/`, `.claude/crystallizer.log` into a single `.claude/` ignore so new session-local artifacts (crystallizer symlinks, status panel pointers, future harness files) don't trip `/wavemachine` pre-flight "base branch clean" checks.

## Changes

- `.gitignore`: three enumerated `.claude/...` entries → one `.claude/` entry.

## Linked Issues

Closes #48

## Test Plan

- [x] `git status --porcelain` on feature branch shows no `.claude/` entry after the change (verified).
- [x] No tracked files were removed (the enumerated ignores only matched untracked paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)