### PR TITLE
feat(makefile): add apply-dry, apply, verify targets and extended lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,55 @@
-# beget — build targets (additional targets will be added in issue #7)
+# beget — build targets
+#
+# Core targets (issue #7): help, lint, apply-dry, apply, verify.
+# Test-related targets from issue #5 retained for continuity.
 
 SHELL := /bin/bash
 
-.PHONY: help bootstrap-test-deps lint test-unit
+.PHONY: help bootstrap-test-deps lint apply-dry apply verify test-unit
 
 help:
 	@echo "beget — available targets:"
+	@echo "  help                 show this message (default)"
+	@echo "  lint                 run shellcheck on install.sh, lib/*.sh, run_onchange_*"
+	@echo "  apply-dry            chezmoi apply --dry-run --verbose"
+	@echo "  apply                chezmoi apply --verbose"
+	@echo "  verify               chezmoi verify (reports drift)"
 	@echo "  bootstrap-test-deps  initialize the bats-core git submodule"
-	@echo "  lint                 run shellcheck on lib/*.sh"
 	@echo "  test-unit            run bats-core unit tests"
 
-# Ensure the bats-core submodule is checked out before running the test suite.
+# ---- Linting ----------------------------------------------------------------
+# Shellcheck every bash file we own: the bootstrap entry, the sourced library,
+# and any run_onchange_* scripts chezmoi will execute. Globs are expanded with
+# nullglob so a currently-empty run_onchange_* set does not fail the build.
+lint:
+	@set -euo pipefail; \
+	shopt -s nullglob; \
+	files=(); \
+	[[ -f install.sh ]] && files+=(install.sh); \
+	files+=(lib/*.sh); \
+	files+=(run_onchange_*); \
+	if [[ $${#files[@]} -eq 0 ]]; then \
+	    echo "lint: no files to check"; \
+	    exit 0; \
+	fi; \
+	echo "shellcheck $${files[*]}"; \
+	shellcheck "$${files[@]}"
+
+# ---- Chezmoi wrappers -------------------------------------------------------
+
+apply-dry:
+	chezmoi apply --dry-run --verbose
+
+apply:
+	chezmoi apply --verbose
+
+verify:
+	chezmoi verify
+
+# ---- Tests ------------------------------------------------------------------
+
 bootstrap-test-deps:
 	git submodule update --init --recursive tests/bats
-
-lint:
-	shellcheck lib/*.sh
 
 test-unit: bootstrap-test-deps
 	tests/bats/bin/bats tests/unit


### PR DESCRIPTION
## Summary

Extends the scaffolding Makefile with the core developer-loop targets for wave 1.2 issue #7: `help` (default), `lint`, `apply-dry`, `apply`, `verify`. Retains `bootstrap-test-deps` and `test-unit` from #5. The `test` target is deferred to Phase 3 per the Dev Spec.

## Changes

- MODIFY `Makefile`:
  - `help` (default) documents all targets.
  - `lint` runs shellcheck on `install.sh` + `lib/*.sh` + `run_onchange_*`. Nullglob-safe so a missing `install.sh` or empty glob does not break the build.
  - `apply-dry` → `chezmoi apply --dry-run --verbose`.
  - `apply` → `chezmoi apply --verbose`.
  - `verify` → `chezmoi verify`.
  - `.PHONY` updated for all new targets.

## Test Plan

- `make` — shows help.
- `make lint` — passes on a clean tree; verified it aborts non-zero on a deliberately-broken `lib/bad.sh`.
- `make test-unit` — 20/20 platform tests pass.
- `make apply-dry` / `make verify` — invoke chezmoi correctly (read-only on a box with chezmoi installed).

## Linked Issues

Closes #7
