### PR TITLE
feat(dotfiles): baseline bash/tmux/ghostty/direnv/inputrc via chezmoi

### DIFF
--- a/dot_bash_aliases
+++ b/dot_bash_aliases
@@ -1,0 +1,32 @@
+# ~/.bash_aliases — managed by chezmoi via beget
+#
+# Personal shell aliases. Sourced by ~/.bashrc when present.
+
+# ls family — color output on both GNU and BSD ls (GNU is the default on both
+# supported platforms).
+if command -v dircolors >/dev/null 2>&1; then
+    alias ls='ls --color=auto'
+fi
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Grep with color when the target is a terminal (GNU grep's default).
+alias grep='grep --color=auto'
+alias fgrep='fgrep --color=auto'
+alias egrep='egrep --color=auto'
+
+# Editor convenience. vi invokes vim when present; falls through otherwise.
+if command -v vim >/dev/null 2>&1; then
+    alias vi='vim'
+fi
+
+# Quality-of-life.
+alias ..='cd ..'
+alias ...='cd ../..'
+alias h='history'
+
+# Safe-by-default destructive commands.
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -1,0 +1,60 @@
+# ~/.bashrc — managed by chezmoi via beget
+#
+# Baseline interactive-shell init. Secret-dependent exports are deliberately
+# omitted here; they will live in dot_bashrc.d/executable_50-wrappers.sh
+# (introduced by a later wave). Keep this file idempotent and safe to re-source.
+
+# If not running interactively, don't do anything.
+case $- in
+    *i*) ;;
+    *) return ;;
+esac
+
+# ---- History -----------------------------------------------------------------
+HISTCONTROL=ignoreboth
+HISTSIZE=10000
+HISTFILESIZE=20000
+shopt -s histappend
+shopt -s checkwinsize
+
+# ---- Prompt ------------------------------------------------------------------
+# Enable color prompt when the terminal supports it.
+case "$TERM" in
+    xterm-color|*-256color|xterm-kitty|ghostty) color_prompt=yes ;;
+esac
+
+if [ "$color_prompt" = yes ]; then
+    PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='\u@\h:\w\$ '
+fi
+unset color_prompt
+
+# ---- Aliases ----------------------------------------------------------------
+if [ -f "$HOME/.bash_aliases" ]; then
+    # shellcheck source=/dev/null
+    . "$HOME/.bash_aliases"
+fi
+
+# ---- Drop-in fragments ------------------------------------------------------
+# dot_bashrc.d/*.sh contains shared helpers (PATH, tool hooks). Sourced in
+# lexicographic order so 10-common.sh lands before 50-wrappers.sh, etc.
+if [ -d "$HOME/.bashrc.d" ]; then
+    for _f in "$HOME"/.bashrc.d/*.sh; do
+        [ -r "$_f" ] || continue
+        # shellcheck source=/dev/null
+        . "$_f"
+    done
+    unset _f
+fi
+
+# ---- Bash completion --------------------------------------------------------
+if ! shopt -oq posix; then
+    if [ -f /usr/share/bash-completion/bash_completion ]; then
+        # shellcheck source=/dev/null
+        . /usr/share/bash-completion/bash_completion
+    elif [ -f /etc/bash_completion ]; then
+        # shellcheck source=/dev/null
+        . /etc/bash_completion
+    fi
+fi

--- a/dot_bashrc.d/10-common.sh
+++ b/dot_bashrc.d/10-common.sh
@@ -1,0 +1,53 @@
+# ~/.bashrc.d/10-common.sh — managed by chezmoi via beget
+#
+# Shared interactive-shell bootstrap. Runs after the main ~/.bashrc has
+# loaded aliases and history. Idempotent — safe to re-source.
+#
+# Load order convention: 10 (common) → 50 (secret wrappers, added later) → 90.
+
+# ---- PATH -------------------------------------------------------------------
+# R-39: $HOME/.local/bin precedes /usr/bin and /usr/local/bin. Prepend in
+# reverse order so the final PATH reads ~/.local/bin : ~/.cargo/bin : original.
+
+_beget_path_prepend() {
+    local dir="$1"
+    case ":$PATH:" in
+        *":$dir:"*) return 0 ;;
+    esac
+    if [ -d "$dir" ]; then
+        PATH="$dir:$PATH"
+    fi
+}
+
+_beget_path_prepend "$HOME/.cargo/bin"
+_beget_path_prepend "$HOME/.local/bin"
+export PATH
+
+# ---- zoxide ------------------------------------------------------------------
+# Smarter `cd`. Registers the `z` command; silently skipped if zoxide is not
+# installed on this host.
+if command -v zoxide >/dev/null 2>&1; then
+    eval "$(zoxide init bash)"
+fi
+
+# ---- fzf ---------------------------------------------------------------------
+# Fuzzy finder key bindings + completion. Ships either as /usr/share/fzf on
+# Debian/Ubuntu or under ~/.fzf.bash depending on install method.
+if [ -r /usr/share/doc/fzf/examples/key-bindings.bash ]; then
+    # shellcheck source=/dev/null
+    . /usr/share/doc/fzf/examples/key-bindings.bash
+fi
+if [ -r /usr/share/bash-completion/completions/fzf ]; then
+    # shellcheck source=/dev/null
+    . /usr/share/bash-completion/completions/fzf
+elif [ -r "$HOME/.fzf.bash" ]; then
+    # shellcheck source=/dev/null
+    . "$HOME/.fzf.bash"
+fi
+
+# ---- direnv ------------------------------------------------------------------
+# Per-directory env management. Placeholder hook — the full wiring lands in
+# the direnv wave; this guards against a missing binary cleanly.
+if command -v direnv >/dev/null 2>&1; then
+    eval "$(direnv hook bash)"
+fi

--- a/dot_config/direnv/config.toml
+++ b/dot_config/direnv/config.toml
@@ -1,0 +1,12 @@
+# ~/.config/direnv/direnv.toml — managed by chezmoi via beget
+#
+# direnv v2.28+ uses direnv.toml. Policy: no implicit whitelist — every
+# project .envrc must be allowed explicitly via `direnv allow`. This keeps
+# `secret_get` invocations from firing on arbitrary cd.
+
+[global]
+# Do not auto-load anything without explicit allow.
+warn_timeout = "5s"
+# Disable auto-approve via path whitelisting — intentional friction.
+# (direnv honors this by having no [whitelist] table; documented here so
+# future edits do not accidentally introduce one.)

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,0 +1,42 @@
+# ~/.config/ghostty/config — managed by chezmoi via beget
+#
+# IBM CGA palette. 16 colors mirrored from the classic DOS CGA/VGA text-mode
+# palette. Reference: https://en.wikipedia.org/wiki/Color_Graphics_Adapter
+#
+# Standard 16 (dim black/bright white at positions 0 and 15). Hex values are
+# canonical CGA — the "brown" slot (3) is rendered as yellow in text mode,
+# per the VGA text-mode convention ghostty/tmux expect.
+
+# ---- Palette ---------------------------------------------------------------
+palette = 0=#000000
+palette = 1=#AA0000
+palette = 2=#00AA00
+palette = 3=#AA5500
+palette = 4=#0000AA
+palette = 5=#AA00AA
+palette = 6=#00AAAA
+palette = 7=#AAAAAA
+palette = 8=#555555
+palette = 9=#FF5555
+palette = 10=#55FF55
+palette = 11=#FFFF55
+palette = 12=#5555FF
+palette = 13=#FF55FF
+palette = 14=#55FFFF
+palette = 15=#FFFFFF
+
+# Foreground / background match CGA text mode (bright white on black).
+foreground = #AAAAAA
+background = #000000
+cursor-color = #FFFF55
+selection-foreground = #000000
+selection-background = #AAAAAA
+
+# ---- Font ------------------------------------------------------------------
+font-family = "IBM Plex Mono"
+font-size = 11
+
+# ---- Behavior --------------------------------------------------------------
+cursor-style = block
+window-padding-x = 6
+window-padding-y = 6

--- a/dot_config/tmux/scripts/README.md
+++ b/dot_config/tmux/scripts/README.md
@@ -1,0 +1,3 @@
+# ~/.config/tmux/scripts/
+
+Placeholder for tmux helper scripts. Populated by subsequent waves.

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -1,0 +1,60 @@
+# ~/.config/tmux/tmux.conf — managed by chezmoi via beget
+#
+# IBM CGA color palette. Prefix re-bound to C-Space per BJ's baseline.
+
+# ---- Prefix -----------------------------------------------------------------
+unbind C-b
+set -g prefix C-Space
+bind C-Space send-prefix
+
+# ---- Defaults ---------------------------------------------------------------
+set -g base-index 1
+setw -g pane-base-index 1
+set -g history-limit 50000
+set -g mouse on
+set -sg escape-time 10
+set -g focus-events on
+set -g default-terminal "tmux-256color"
+set -as terminal-overrides ",*:RGB"
+
+# ---- IBM CGA theme ----------------------------------------------------------
+# Classic CGA palette: black / red / green / yellow / blue / magenta / cyan /
+# white as cogent 16-color ANSI equivalents. Status line uses CGA brown-as-
+# yellow on black, reverse on active windows.
+
+cga_black="colour0"
+cga_red="colour1"
+cga_green="colour2"
+cga_yellow="colour3"
+cga_blue="colour4"
+cga_magenta="colour5"
+cga_cyan="colour6"
+cga_white="colour7"
+cga_bright_yellow="colour11"
+cga_bright_white="colour15"
+
+set -g status-style "fg=${cga_bright_white},bg=${cga_black}"
+set -g status-left "#[fg=${cga_bright_yellow},bg=${cga_blue}] #S #[default] "
+set -g status-left-length 30
+set -g status-right "#[fg=${cga_cyan}]%Y-%m-%d #[fg=${cga_bright_yellow}]%H:%M "
+set -g status-right-length 40
+
+setw -g window-status-style "fg=${cga_white},bg=${cga_black}"
+setw -g window-status-current-style "fg=${cga_black},bg=${cga_bright_yellow},bold"
+setw -g window-status-format " #I:#W "
+setw -g window-status-current-format " #I:#W "
+
+set -g pane-border-style "fg=${cga_blue}"
+set -g pane-active-border-style "fg=${cga_bright_yellow}"
+
+set -g message-style "fg=${cga_black},bg=${cga_bright_yellow}"
+
+# ---- Keybindings ------------------------------------------------------------
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+bind r source-file ~/.config/tmux/tmux.conf \; display "reloaded"
+
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R

--- a/dot_inputrc
+++ b/dot_inputrc
@@ -1,0 +1,18 @@
+# ~/.inputrc — managed by chezmoi via beget
+#
+# Readline settings. Keep minimal and POSIX-friendly so that vi-mode lovers
+# and emacs-mode defaults both remain sane.
+
+# Respect the system inputrc when present.
+$include /etc/inputrc
+
+# Case-insensitive completion and visual indicators.
+set completion-ignore-case On
+set show-all-if-ambiguous On
+set visible-stats On
+set colored-stats On
+set mark-symlinked-directories On
+
+# History search via up/down arrows against the current prefix.
+"\e[A": history-search-backward
+"\e[B": history-search-forward

--- a/dot_profile
+++ b/dot_profile
@@ -1,0 +1,20 @@
+# ~/.profile — managed by chezmoi via beget
+#
+# Runs once per login session, before ~/.bashrc. Sources ~/.bashrc when the
+# shell is bash so a login bash shell picks up interactive setup.
+
+# If running bash, source ~/.bashrc.
+if [ -n "${BASH_VERSION-}" ]; then
+    if [ -f "$HOME/.bashrc" ]; then
+        # shellcheck source=/dev/null
+        . "$HOME/.bashrc"
+    fi
+fi
+
+# R-39: ensure ~/.local/bin is on PATH for non-interactive login shells too.
+# The idempotent guard matches dot_bashrc.d/10-common.sh.
+case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) if [ -d "$HOME/.local/bin" ]; then PATH="$HOME/.local/bin:$PATH"; fi ;;
+esac
+export PATH


### PR DESCRIPTION
## Summary

Ports the minimal dotfile baseline required for a working shell after bootstrap (wave 1.3, #8). All content is secret-free — `secret_get`/rbw wrappers land in a later wave per Dev Spec §5.3.

## Changes

- CREATE `dot_bashrc` — interactive bash init with drop-in loader for `~/.bashrc.d/*.sh`.
- CREATE `dot_bash_aliases` — `ls`/`ll`/`grep`/`vi`/`rm -i`/`cp -i`/`mv -i` family plus `..`/`...`/`h`.
- CREATE `dot_bashrc.d/10-common.sh` — PATH prepend honoring R-39 (`~/.local/bin` precedes system bins, `~/.cargo/bin` included), zoxide/fzf/direnv hooks with existence guards.
- CREATE `dot_profile` — login-shell PATH + bashrc source.
- CREATE `dot_inputrc` — case-insensitive completion, history prefix search.
- CREATE `dot_config/tmux/tmux.conf` — `C-Space` prefix, IBM CGA 16-color palette, mouse, split keybinds.
- CREATE `dot_config/tmux/scripts/README.md` — placeholder so the dir is tracked.
- CREATE `dot_config/ghostty/config` — IBM CGA palette (16 canonical CGA hex colors), IBM Plex Mono, block cursor.
- CREATE `dot_config/direnv/config.toml` — no implicit whitelist (intentional friction per Dev Spec §5.4).

## Test Plan

- `shellcheck -s bash dot_bashrc dot_bash_aliases dot_bashrc.d/10-common.sh dot_profile` — clean.
- `make test-unit` — 28/28 existing bats suite regresses clean.
- Structural AC verification (runtime via `chezmoi apply` on a live host): prompt present, aliases present, PATH order, `C-Space` prefix, CGA palette, no secret refs.

## Linked Issues

Closes #8
