### PR TITLE
feat(git): identity config with analogicdev includeIf override

### DIFF
--- a/dot_gitconfig-analogic
+++ b/dot_gitconfig-analogic
@@ -1,0 +1,8 @@
+; ~/.gitconfig-analogic — managed by chezmoi via beget
+;
+; Included by ~/.gitconfig when the active repo has a remote under
+; git@gitlab.com:analogicdev/**. Overrides user.email to the Analogic
+; address; inherits user.name from the base config.
+
+[user]
+    email = brbaker@analogic.com

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,0 +1,48 @@
+; ~/.gitconfig — managed by chezmoi via beget
+;
+; Default (personal) git identity. Per-context overrides are applied via
+; `includeIf` matchers below; see README / Dev Spec §5.4 for the full context
+; story. Credentials are NEVER written here — all auth goes through
+; credential helpers or SSH keys materialized by a later wave.
+
+[user]
+    name  = Brian Baker
+    email = brian@waveeng.com
+
+[init]
+    defaultBranch = main
+
+[pull]
+    rebase = true
+
+[push]
+    autoSetupRemote = true
+    default = simple
+
+[rebase]
+    autoStash = true
+
+[fetch]
+    prune = true
+
+[core]
+    editor = vim
+    autocrlf = input
+    pager = less -FRX
+
+[color]
+    ui = auto
+
+[filter "lfs"]
+    clean    = git-lfs clean -- %f
+    smudge   = git-lfs smudge -- %f
+    process  = git-lfs filter-process
+    required = true
+
+; ---- Per-context identity (R-24, R-25) --------------------------------------
+; Requires git >= 2.36 for the `hasconfig:remote.*.url` matcher. When a clone
+; has a remote whose URL starts with git@gitlab.com:analogicdev/, the Analogic
+; override file is included and overrides user.email.
+
+[includeIf "hasconfig:remote.*.url:git@gitlab.com:analogicdev/**"]
+    path = ~/.gitconfig-analogic

--- a/tests/unit/gitconfig.bats
+++ b/tests/unit/gitconfig.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# tests/unit/gitconfig.bats — unit tests for git identity dotfiles
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    GITCONFIG_TMPL="$REPO_ROOT/dot_gitconfig.tmpl"
+    GITCONFIG_ANALOGIC="$REPO_ROOT/dot_gitconfig-analogic"
+}
+
+@test "dot_gitconfig.tmpl: exists and is readable" {
+    [ -r "$GITCONFIG_TMPL" ]
+}
+
+@test "dot_gitconfig-analogic: exists and is readable" {
+    [ -r "$GITCONFIG_ANALOGIC" ]
+}
+
+@test "dot_gitconfig.tmpl: parseable as a git config file" {
+    # `git config -l -f <file>` errors on malformed INI.
+    run git config -l -f "$GITCONFIG_TMPL"
+    [ "$status" -eq 0 ]
+}
+
+@test "dot_gitconfig-analogic: parseable as a git config file" {
+    run git config -l -f "$GITCONFIG_ANALOGIC"
+    [ "$status" -eq 0 ]
+}
+
+@test "dot_gitconfig.tmpl: has personal user.email" {
+    run git config -f "$GITCONFIG_TMPL" user.email
+    [ "$status" -eq 0 ]
+    [ "$output" = "brian@waveeng.com" ]
+}
+
+@test "dot_gitconfig.tmpl: has user.name" {
+    run git config -f "$GITCONFIG_TMPL" user.name
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "dot_gitconfig.tmpl: declares filter.lfs" {
+    run git config -f "$GITCONFIG_TMPL" filter.lfs.required
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+}
+
+@test "dot_gitconfig.tmpl: contains includeIf for analogicdev (R-24)" {
+    run grep -F 'includeIf "hasconfig:remote.*.url:git@gitlab.com:analogicdev/**"' "$GITCONFIG_TMPL"
+    [ "$status" -eq 0 ]
+}
+
+@test "dot_gitconfig.tmpl: includeIf points at ~/.gitconfig-analogic" {
+    # git config exposes the value via the section key.
+    local key='includeif.hasconfig:remote.*.url:git@gitlab.com:analogicdev/**.path'
+    run git config -f "$GITCONFIG_TMPL" "$key"
+    [ "$status" -eq 0 ]
+    [ "$output" = "~/.gitconfig-analogic" ]
+}
+
+@test "dot_gitconfig-analogic: overrides user.email to Analogic (R-24)" {
+    run git config -f "$GITCONFIG_ANALOGIC" user.email
+    [ "$status" -eq 0 ]
+    [ "$output" = "brbaker@analogic.com" ]
+}
+
+@test "dot_gitconfig.tmpl: no credentials/tokens present" {
+    # Smoke: any line that looks password/token-shaped is forbidden.
+    run grep -iE 'password|token|secret|api[_-]?key' "$GITCONFIG_TMPL"
+    [ "$status" -ne 0 ]
+}
+
+@test "dot_gitconfig-analogic: no credentials/tokens present" {
+    run grep -iE 'password|token|secret|api[_-]?key' "$GITCONFIG_ANALOGIC"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

Git identity for wave 1.3 issue #9. Default personal identity uses `brian@waveeng.com`; repos with a remote under `git@gitlab.com:analogicdev/**` pick up `~/.gitconfig-analogic` via the git ≥2.36 `hasconfig:remote.*.url:` matcher and override `user.email` to `brbaker@analogic.com`.

## Changes

- CREATE `dot_gitconfig.tmpl` — base personal identity, core settings, `filter.lfs`, `includeIf` for the Analogic override.
- CREATE `dot_gitconfig-analogic` — email override for Analogic repos.
- CREATE `tests/unit/gitconfig.bats` — 12 tests: file parseability via `git config -f`, correct default/override emails, `includeIf` matcher & target path, no credentials.

## Test Plan

- `tests/bats/bin/bats tests/unit/` — 40/40 passing (12 new + 28 existing).
- R-24: Analogic override yields `brbaker@analogic.com` — test #10.
- R-25: Personal default yields `brian@waveeng.com` — test #5.
- git ≥2.36 `includeIf hasconfig` syntax — tests #8, #9.
- Credential-free contract — tests #11, #12.

## Linked Issues

Closes #9
