### PR TITLE
feat(secrets): shell secret helpers and gh/glab/bao wrappers

### DIFF
--- a/dot_bashrc.d/executable_50-wrappers.sh
+++ b/dot_bashrc.d/executable_50-wrappers.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# ~/.bashrc.d/50-wrappers.sh — managed by chezmoi via beget
+#
+# Lazy secret materialization + tool wrappers.
+#
+# Sourced by ~/.bashrc via the drop-in loader (10-common.sh already set up
+# PATH and hooks). Safe to re-source — all function definitions are
+# idempotent and no top-level side effects fire.
+#
+# Public surface:
+#   secret VAR [ITEM]          Lazily populate $VAR via `rbw get`. ITEM
+#                              overrides the default item name derivation.
+#                              Sets VAR in the caller's shell. Returns 0 on
+#                              success, 1 on missing-item / rbw failure.
+#   secret_get ITEM            Print the secret to stdout without mutating
+#                              the env. Returns 0 on success, 1 on failure.
+#   _secret_file_from_var VAR  Convert an env-var name (GITHUB_PAT) into its
+#                              canonical rbw item name (github-pat). Echoes
+#                              on stdout.
+#   gh / glab / bao            Wrappers that materialize GITHUB_PAT,
+#                              GITLAB_TOKEN, BAO_TOKEN respectively before
+#                              dispatching to the real binary. Failure to
+#                              materialize stops the invocation (R-16).
+#
+# Test seams (env-var overrides):
+#   BEGET_RBW_CMD       name of the rbw binary (default: rbw).
+#   BEGET_WARN          redirect warnings (default: stderr).
+#
+# References: R-13, R-14, R-15, R-16 in docs/beget-devspec.md.
+
+# ---- Name conversion (R-15) --------------------------------------------------
+# Lowercase + underscores-to-dashes. Example: GITHUB_PAT -> github-pat.
+# Kept as _-prefixed because callers should not depend on this directly.
+_secret_file_from_var() {
+    local name="${1:-}"
+    if [[ -z "$name" ]]; then
+        return 1
+    fi
+    # bash 4+ parameter expansion: case-lower, tr-style replace.
+    local lower="${name,,}"
+    printf '%s' "${lower//_/-}"
+}
+
+# ---- Warning helper ----------------------------------------------------------
+# Routes via BEGET_WARN when set so tests can capture warnings without
+# colliding with bats' own stderr handling.
+_secret_warn() {
+    if [[ -n "${BEGET_WARN:-}" ]]; then
+        printf '%s\n' "$*" >>"$BEGET_WARN"
+    else
+        printf 'secret: %s\n' "$*" >&2
+    fi
+}
+
+# ---- rbw invocation seam -----------------------------------------------------
+# Wraps rbw so tests can substitute a shim without touching PATH. Honors
+# BEGET_RBW_CMD (default: `rbw`).
+_secret_rbw_get() {
+    local item="$1"
+    local cmd="${BEGET_RBW_CMD:-rbw}"
+    "$cmd" get "$item"
+}
+
+# ---- secret (R-13) -----------------------------------------------------------
+# Lazily populate an env var. If the var already has a non-empty value, do
+# nothing (idempotency). Otherwise, look up the item name, call rbw, and
+# export into the caller's shell.
+#
+# Usage:
+#   secret GITHUB_PAT             item name derives as github-pat
+#   secret GITLAB_TOKEN analogic-gitlab-token
+secret() {
+    local var="${1:-}"
+    local item="${2:-}"
+
+    if [[ -z "$var" ]]; then
+        _secret_warn "usage: secret VAR [ITEM]"
+        return 1
+    fi
+
+    # R-13: already populated? Skip.
+    if [[ -n "${!var:-}" ]]; then
+        return 0
+    fi
+
+    if [[ -z "$item" ]]; then
+        item="$(_secret_file_from_var "$var")"
+    fi
+
+    local value
+    if ! value="$(_secret_rbw_get "$item")" || [[ -z "$value" ]]; then
+        _secret_warn "rbw get '$item' failed (for \$$var)"
+        return 1
+    fi
+
+    # Export so subprocesses see it. Caller is responsible for scope.
+    export "$var=$value"
+    return 0
+}
+
+# ---- secret_get (R-14) -------------------------------------------------------
+# Retrieve a secret and print to stdout. Does NOT export or otherwise mutate
+# the caller's env. Accepts the rbw item name directly (contrast with
+# `secret`, which takes an env-var name). This lets .envrc use the idiomatic
+# `export VAR=$(secret_get <context>-<name>)` form (R-29).
+secret_get() {
+    local item="${1:-}"
+    if [[ -z "$item" ]]; then
+        _secret_warn "usage: secret_get ITEM"
+        return 1
+    fi
+
+    local value
+    if ! value="$(_secret_rbw_get "$item")" || [[ -z "$value" ]]; then
+        _secret_warn "rbw get '$item' failed"
+        return 1
+    fi
+
+    printf '%s' "$value"
+    return 0
+}
+
+# ---- Tool wrappers (R-16) ----------------------------------------------------
+# Each wrapper materializes the tool's auth secret (if empty) and dispatches
+# to the real binary via `command`. Materialization failure returns non-zero
+# WITHOUT running the tool, so broken auth can never produce a stale call.
+
+gh() {
+    secret GITHUB_PAT || return 1
+    command gh "$@"
+}
+
+glab() {
+    secret GITLAB_TOKEN || return 1
+    command glab "$@"
+}
+
+bao() {
+    secret BAO_TOKEN || return 1
+    command bao "$@"
+}

--- a/tests/unit/wrappers.bats
+++ b/tests/unit/wrappers.bats
@@ -1,0 +1,308 @@
+#!/usr/bin/env bats
+# tests/unit/wrappers.bats — unit tests for dot_bashrc.d/executable_50-wrappers.sh
+#
+# Strategy: source the library, then swap BEGET_RBW_CMD to a shim script
+# under BATS_TEST_TMPDIR so rbw calls are deterministic and hermetic.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    WRAPPERS_SH="$REPO_ROOT/dot_bashrc.d/executable_50-wrappers.sh"
+
+    # Shim dir for fake rbw.
+    SHIM_DIR="$BATS_TEST_TMPDIR/shim"
+    mkdir -p "$SHIM_DIR"
+    export BEGET_RBW_CMD="$SHIM_DIR/rbw"
+
+    # Warning capture file so we can assert messages without relying on
+    # bats stderr interleaving.
+    export BEGET_WARN="$BATS_TEST_TMPDIR/warnings.log"
+    : >"$BEGET_WARN"
+
+    # shellcheck source=/dev/null
+    source "$WRAPPERS_SH"
+}
+
+# Helper: install an rbw shim with given behavior.
+#   $1 = behavior keyword: ok | missing | locked | unreachable
+#   $2 = (optional) stdout for 'ok' mode
+make_rbw() {
+    local behavior="$1"
+    local out="${2:-secret-value}"
+    cat >"$BEGET_RBW_CMD" <<EOF
+#!/usr/bin/env bash
+# Fake rbw shim for bats tests
+case "\${2:-}" in
+EOF
+
+    case "$behavior" in
+        ok)
+            cat >>"$BEGET_RBW_CMD" <<EOF
+  *) printf '%s' '$out'; exit 0 ;;
+EOF
+            ;;
+        missing)
+            cat >>"$BEGET_RBW_CMD" <<EOF
+  *) echo "rbw get: no item named \$2" >&2; exit 1 ;;
+EOF
+            ;;
+        locked)
+            cat >>"$BEGET_RBW_CMD" <<EOF
+  *) echo "rbw is locked" >&2; exit 2 ;;
+EOF
+            ;;
+        unreachable)
+            cat >>"$BEGET_RBW_CMD" <<EOF
+  *) echo "rbw: network error" >&2; exit 3 ;;
+EOF
+            ;;
+    esac
+    echo "esac" >>"$BEGET_RBW_CMD"
+    chmod +x "$BEGET_RBW_CMD"
+}
+
+# ---- R-15: name conversion --------------------------------------------------
+
+@test "_secret_file_from_var: GITHUB_PAT -> github-pat" {
+    run _secret_file_from_var GITHUB_PAT
+    [ "$status" -eq 0 ]
+    [ "$output" = "github-pat" ]
+}
+
+@test "_secret_file_from_var: GITLAB_TOKEN -> gitlab-token" {
+    run _secret_file_from_var GITLAB_TOKEN
+    [ "$status" -eq 0 ]
+    [ "$output" = "gitlab-token" ]
+}
+
+@test "_secret_file_from_var: BAO_TOKEN -> bao-token" {
+    run _secret_file_from_var BAO_TOKEN
+    [ "$status" -eq 0 ]
+    [ "$output" = "bao-token" ]
+}
+
+@test "_secret_file_from_var: ANALOGIC_GITLAB_TOKEN -> analogic-gitlab-token" {
+    run _secret_file_from_var ANALOGIC_GITLAB_TOKEN
+    [ "$status" -eq 0 ]
+    [ "$output" = "analogic-gitlab-token" ]
+}
+
+@test "_secret_file_from_var: empty input fails" {
+    run _secret_file_from_var ""
+    [ "$status" -ne 0 ]
+}
+
+# ---- R-13: secret() lazy materialization ------------------------------------
+
+@test "secret: materializes from rbw when VAR is empty" {
+    make_rbw ok "pat-value-xyz"
+    unset GITHUB_PAT
+    secret GITHUB_PAT
+    [ "$GITHUB_PAT" = "pat-value-xyz" ]
+}
+
+@test "secret: skips materialization when VAR already set (R-13)" {
+    # Even with a broken rbw, a pre-set VAR must not trigger rbw.
+    make_rbw missing
+    export GITHUB_PAT="preexisting"
+    run secret GITHUB_PAT
+    [ "$status" -eq 0 ]
+    # Value unchanged.
+    [ "$GITHUB_PAT" = "preexisting" ]
+    # Nothing was warned, because rbw wasn't called.
+    [ ! -s "$BEGET_WARN" ]
+}
+
+@test "secret: override arg wins over derived item name" {
+    # Shim captures the arg and echos a distinct value only for the
+    # override name.
+    cat >"$BEGET_RBW_CMD" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$2" = "analogic-gitlab-token" ]]; then
+  printf 'ANALOGIC'
+elif [[ "$2" = "gitlab-token" ]]; then
+  printf 'PERSONAL'
+else
+  exit 1
+fi
+EOF
+    chmod +x "$BEGET_RBW_CMD"
+    unset GITLAB_TOKEN
+    secret GITLAB_TOKEN analogic-gitlab-token
+    [ "$GITLAB_TOKEN" = "ANALOGIC" ]
+}
+
+@test "secret: missing rbw item -> return 1, warns, env unchanged" {
+    make_rbw missing
+    unset GITHUB_PAT
+    run secret GITHUB_PAT
+    [ "$status" -eq 1 ]
+    # Warning captured.
+    grep -q 'rbw get' "$BEGET_WARN"
+}
+
+@test "secret: rbw locked -> return 1" {
+    make_rbw locked
+    unset GITHUB_PAT
+    run secret GITHUB_PAT
+    [ "$status" -eq 1 ]
+}
+
+@test "secret: rbw unreachable -> return 1" {
+    make_rbw unreachable
+    unset GITHUB_PAT
+    run secret GITHUB_PAT
+    [ "$status" -eq 1 ]
+}
+
+@test "secret: missing VAR arg -> usage error" {
+    run secret
+    [ "$status" -eq 1 ]
+    grep -q 'usage' "$BEGET_WARN"
+}
+
+# ---- R-14: secret_get() prints without exporting ----------------------------
+
+@test "secret_get: prints the value on stdout" {
+    make_rbw ok "hello-world"
+    run secret_get any-item
+    [ "$status" -eq 0 ]
+    [ "$output" = "hello-world" ]
+}
+
+@test "secret_get: does NOT mutate the env (R-14)" {
+    make_rbw ok "hello-world"
+    unset GITHUB_PAT
+    out="$(secret_get github-pat)"
+    [ "$out" = "hello-world" ]
+    # GITHUB_PAT must still be unset.
+    [ -z "${GITHUB_PAT:-}" ]
+}
+
+@test "secret_get: missing item -> return 1" {
+    make_rbw missing
+    run secret_get nope
+    [ "$status" -eq 1 ]
+}
+
+@test "secret_get: missing item arg -> usage error" {
+    run secret_get
+    [ "$status" -eq 1 ]
+    grep -q 'usage' "$BEGET_WARN"
+}
+
+# ---- R-16: tool wrappers materialize on first call --------------------------
+
+@test "gh wrapper: returns non-zero when GITHUB_PAT cannot be materialized" {
+    make_rbw missing
+    unset GITHUB_PAT
+    # Provide a stub `gh` that would succeed if reached. The wrapper should
+    # NOT reach it because secret() fails first.
+    local stub_dir="$BATS_TEST_TMPDIR/stubs"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'REAL_GH_SHOULD_NOT_RUN'
+EOF
+    chmod +x "$stub_dir/gh"
+    PATH="$stub_dir:$PATH"
+    run gh pr list
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"REAL_GH_SHOULD_NOT_RUN"* ]]
+}
+
+@test "gh wrapper: materializes GITHUB_PAT on first call, reuses on second (R-16)" {
+    # rbw writes a call-count file and returns a unique value per call.
+    # We assert that after two gh invocations, rbw was called exactly once
+    # and the same GITHUB_PAT was visible to both gh invocations — the
+    # correct definition of "materialize once per session, reuse."
+    cat >"$BEGET_RBW_CMD" <<'EOF'
+#!/usr/bin/env bash
+count_file="$BEGET_RBW_COUNT_FILE"
+if [[ -f "$count_file" ]]; then
+  n=$(cat "$count_file"); n=$((n+1))
+else
+  n=1
+fi
+echo "$n" >"$count_file"
+printf 'pat-%d' "$n"
+EOF
+    chmod +x "$BEGET_RBW_CMD"
+    export BEGET_RBW_COUNT_FILE="$BATS_TEST_TMPDIR/rbwcount"
+    unset GITHUB_PAT
+
+    # Stub the real gh to append the env-visible PAT to a log file.
+    local stub_dir="$BATS_TEST_TMPDIR/stubs"
+    mkdir -p "$stub_dir"
+    export GH_LOG="$BATS_TEST_TMPDIR/ghlog"
+    : >"$GH_LOG"
+    cat >"$stub_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$GITHUB_PAT" >>"$GH_LOG"
+EOF
+    chmod +x "$stub_dir/gh"
+    PATH="$stub_dir:$PATH"
+
+    # Two calls IN THE CURRENT SHELL — not via `run`, which forks a subshell
+    # and would lose the exported GITHUB_PAT between calls.
+    gh pr list
+    gh pr list
+    # rbw must have been called exactly once.
+    [ "$(cat "$BEGET_RBW_COUNT_FILE")" = "1" ]
+    # Both gh invocations saw the same materialized value.
+    mapfile -t seen <"$GH_LOG"
+    [ "${#seen[@]}" -eq 2 ]
+    [ "${seen[0]}" = "pat-1" ]
+    [ "${seen[1]}" = "pat-1" ]
+}
+
+@test "glab wrapper: maps to GITLAB_TOKEN, item gitlab-token" {
+    cat >"$BEGET_RBW_CMD" <<'EOF'
+#!/usr/bin/env bash
+[[ "$2" = "gitlab-token" ]] && { printf 'GL'; exit 0; }
+exit 1
+EOF
+    chmod +x "$BEGET_RBW_CMD"
+    unset GITLAB_TOKEN
+    local stub_dir="$BATS_TEST_TMPDIR/stubs"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/glab" <<'EOF'
+#!/usr/bin/env bash
+printf 'glab:%s' "$GITLAB_TOKEN"
+EOF
+    chmod +x "$stub_dir/glab"
+    PATH="$stub_dir:$PATH"
+    run glab mr list
+    [ "$status" -eq 0 ]
+    [ "$output" = "glab:GL" ]
+}
+
+@test "bao wrapper: maps to BAO_TOKEN, item bao-token" {
+    cat >"$BEGET_RBW_CMD" <<'EOF'
+#!/usr/bin/env bash
+[[ "$2" = "bao-token" ]] && { printf 'BT'; exit 0; }
+exit 1
+EOF
+    chmod +x "$BEGET_RBW_CMD"
+    unset BAO_TOKEN
+    local stub_dir="$BATS_TEST_TMPDIR/stubs"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/bao" <<'EOF'
+#!/usr/bin/env bash
+printf 'bao:%s' "$BAO_TOKEN"
+EOF
+    chmod +x "$stub_dir/bao"
+    PATH="$stub_dir:$PATH"
+    run bao status
+    [ "$status" -eq 0 ]
+    [ "$output" = "bao:BT" ]
+}
+
+# ---- Self-shellcheck --------------------------------------------------------
+
+@test "wrappers.sh: passes shellcheck" {
+    if ! command -v shellcheck >/dev/null 2>&1; then
+        skip "shellcheck not installed"
+    fi
+    run shellcheck -s bash "$WRAPPERS_SH"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Implements wave 2.1 issue #10 — the Subsystem A (shell env-var) side of the secrets architecture per Dev Spec §5.3. All secret reads go through rbw, lazy and cached per shell session.

## Changes

- CREATE `dot_bashrc.d/executable_50-wrappers.sh`:
  - `secret VAR [ITEM]` — R-13 lazy materialization; idempotent guard for already-populated vars; override-arg support for R-29 context-specific secrets.
  - `secret_get ITEM` — R-14 stdout-only retrieval, no env mutation (idiom for `.envrc`).
  - `_secret_file_from_var` — R-15 name conversion (`GITHUB_PAT` → `github-pat`).
  - `gh`/`glab`/`bao` — R-16 wrappers with `|| return 1` failure propagation, dispatching via `command`.
  - Test seams: `BEGET_RBW_CMD` (binary override) and `BEGET_WARN` (warning sink).
- CREATE `tests/unit/wrappers.bats` — 21 tests covering name conversion, `secret` happy+failure paths, `secret_get` no-mutate, wrapper dispatch + call-counting for R-16, self-shellcheck.

Spec deviation: Changes #6 and #7 are no-ops — the `dot_bashrc` shipped in #8 is already secret-free, and its existing drop-in loader for `dot_bashrc.d/*.sh` is the guard.

## Test Plan

- `make test-unit` — 61/61 passing (21 new + 40 existing).
- R-16 verification (test #18): rbw is called exactly once across two `gh` invocations in the same shell, proving "materialize once, reuse."
- Failure paths: missing-item, locked, unreachable rbw all return 1 with captured warnings.
- `shellcheck -s bash` — clean.

## Linked Issues

Closes #10
