### PR TITLE
docs(catalog): SSH identities + AWS profiles skeletons (unblocks wave-2b)

### DIFF
--- a/docs/beget-devspec.md
+++ b/docs/beget-devspec.md
@@ -190,9 +190,9 @@ This project is explicitly NOT:
 
 ### Theme 5 — Secrets: File Materialization (chezmoi-templated)
 
-**R-17** — When `chezmoi apply` runs with rbw initialized, the system shall materialize SSH private keys listed in Catalog Section A to `~/.ssh/` with 0600 permissions.
+**R-17** — When `chezmoi apply` runs with rbw initialized, the system shall materialize SSH private keys listed in Catalog Section A to `~/.ssh/` with 0600 permissions. Catalog Section A is maintained in `docs/catalog-a-ssh-identities.md`.
 
-**R-18** — When `chezmoi apply` runs with rbw initialized, the system shall materialize `~/.aws/credentials` from rbw items matching `aws-<profile>` (for profiles with long-lived creds) with 0600 permissions.
+**R-18** — When `chezmoi apply` runs with rbw initialized, the system shall materialize `~/.aws/credentials` from rbw items matching `aws-<profile>` (for profiles with long-lived creds) with 0600 permissions. Catalog Section B is maintained in `docs/catalog-b-aws-profiles.md`.
 
 **R-19** — When a secret is updated in Vaultwarden and `chezmoi apply` is subsequently invoked, the system shall update dependent materialized files.
 

--- a/docs/catalog-a-ssh-identities.md
+++ b/docs/catalog-a-ssh-identities.md
@@ -1,0 +1,56 @@
+# Catalog A — SSH Identities
+
+**Status:** `placeholder` — BJ fills in rows before wave-2b (#11) executes.
+
+Materialized form of Dev Spec R-17: the SSH private keys that `chezmoi apply`
+materializes under `~/.ssh/`. One row per identity. Agents implementing #11
+read this file; they do not infer or invent entries.
+
+## Schema
+
+| Field | Meaning |
+|---|---|
+| **Identity name** | Short name used throughout (e.g. `id_ed25519`, `blueshift_dev`). Also the base name of the private-key file under `~/.ssh/`. |
+| **Template file** | Path under `dot_ssh/` in the chezmoi source tree, ending `.tmpl`. E.g. `private_id_ed25519.tmpl`. |
+| **VW item** | Vaultwarden item name that stores the private key. Convention: `ssh-<identity>`. |
+| **Key type** | `ed25519`, `rsa-4096`, etc. Drives any `ssh-keygen` helper logic. |
+| **Host block** | The `Host` line (or alias list) in `~/.ssh/config` this key pairs with. |
+| **Match pattern** | The `HostName` / `Host` glob that routes traffic to this key (e.g. `github.com`, `gitlab.analogic.com`, `*.blueshift-dev.internal`). |
+| **Purpose** | One-line description of what the key is for. Optional but recommended. |
+
+## Identities
+
+<!--
+  Fill in concrete rows below. Remove the TODO(BJ) markers when complete.
+  When this table has no TODO(BJ) rows, flip Status above to `filled`.
+-->
+
+| Identity | Template file | VW item | Key type | Host block | Match pattern | Purpose |
+|---|---|---|---|---|---|---|
+| `id_ed25519`            | `private_id_ed25519.tmpl`            | `ssh-id-ed25519`            | ed25519 | TODO(BJ) | TODO(BJ) | Default personal key |
+| `blueshift_dev`         | `private_blueshift_dev.tmpl`         | `ssh-blueshift-dev`         | TODO(BJ) | TODO(BJ) | TODO(BJ) | Blueshift dev env |
+| `blueshift_test`        | `private_blueshift_test.tmpl`        | `ssh-blueshift-test`        | TODO(BJ) | TODO(BJ) | TODO(BJ) | Blueshift test env |
+| `blueshift_prod`        | `private_blueshift_prod.tmpl`        | `ssh-blueshift-prod`        | TODO(BJ) | TODO(BJ) | TODO(BJ) | Blueshift prod env |
+| `analogic_gitlab`       | `private_analogic_gitlab.tmpl`       | `ssh-analogic-gitlab`       | TODO(BJ) | TODO(BJ) | TODO(BJ) | Analogic GitLab |
+| `waveeng_gitlab`        | `private_waveeng_gitlab.tmpl`        | `ssh-waveeng-gitlab`        | TODO(BJ) | TODO(BJ) | TODO(BJ) | Wave Engineering GitLab |
+
+## `~/.ssh/config` ordering
+
+`~/.ssh/config` matches first-win per block. Order rows in `config.tmpl`
+most-specific-first: explicit hostname blocks before wildcards, wildcards
+before the `Host *` default. Agents implementing #11 should preserve the
+order declared in the table above.
+
+## Adding a new identity
+
+1. Append a row above.
+2. Create `dot_ssh/private_<identity>.tmpl` that renders the VW item's `privateKey` field.
+3. Update `dot_ssh/config.tmpl` with the matching `Host` block.
+4. Add a row to the corresponding public-key catalog (if one exists) so `authorized_keys` entries stay in sync.
+5. Flip **Status** back to `placeholder` if the row is TODO until rotated in.
+
+## Out of scope
+
+- Public keys / `authorized_keys` (separate concern; may get its own catalog).
+- Known-hosts pinning (separate theme).
+- Signing keys for git commits (Catalog elsewhere if ever introduced).

--- a/docs/catalog-b-aws-profiles.md
+++ b/docs/catalog-b-aws-profiles.md
@@ -1,0 +1,59 @@
+# Catalog B — AWS Profiles (long-lived credentials)
+
+**Status:** `placeholder` — BJ fills in rows before wave-2b (#12) executes.
+
+Materialized form of Dev Spec R-18: profiles in `~/.aws/credentials` that
+`chezmoi apply` renders from Vaultwarden items. One row per profile. Agents
+implementing #12 read this file; they do not infer or invent entries.
+
+## Scope
+
+Only **long-lived-credential** profiles belong here. Session/SSO profiles
+(e.g. `aws-sso-admin`) do not store static `aws_access_key_id` /
+`aws_secret_access_key` and are expressed in `~/.aws/config` via
+`sso_session` references, not materialized from VW. A separate catalog
+(or simply `~/.aws/config` in `dot_aws/`) covers those.
+
+## Schema
+
+| Field | Meaning |
+|---|---|
+| **Profile name** | The `[<name>]` header in `~/.aws/credentials` (e.g. `default`, `analogic-prod`, `waveeng-billing`). |
+| **VW item** | Vaultwarden item name. Convention: `aws-<profile>`. Fields: `accessKeyId`, `secretAccessKey`, optional `sessionToken` (rare for long-lived), optional `region`. |
+| **Region default** | Default region for the profile (`us-east-1`, etc.). Goes into `~/.aws/config`, not `credentials`, but listed here for completeness. |
+| **Purpose** | One-line description of what the profile is used for. Optional but recommended. |
+
+## Profiles
+
+<!--
+  Fill in concrete rows below. Remove the TODO(BJ) markers when complete.
+  When this table has no TODO(BJ) rows, flip Status above to `filled`.
+-->
+
+| Profile | VW item | Region default | Purpose |
+|---|---|---|---|
+| `default` | `aws-default` | TODO(BJ) | TODO(BJ) — personal-account default |
+
+TODO(BJ): add a row per long-lived profile. If there are *no* long-lived
+profiles (i.e. you only use SSO), say so here and issue #12 should be
+closed as not-applicable rather than implemented.
+
+## `~/.aws/credentials` rendering order
+
+Convention: `default` first, then alphabetical by profile name. Agents
+should follow the order declared in the table above.
+
+## Adding a new profile
+
+1. Append a row above.
+2. Create the `aws-<profile>` item in Vaultwarden with the required fields.
+3. `credentials.tmpl` rebuilds automatically from the catalog — no per-profile
+   template edits needed if the template is a loop over the catalog. If the
+   template is one block per profile, add the block.
+4. Set region in `dot_aws/config.tmpl` under `[profile <name>]`.
+
+## Out of scope
+
+- SSO / session profiles (see Scope above).
+- IAM Identity Center config (`dot_aws/config.tmpl` handles via separate sections).
+- MFA-sourced temporary credentials (not materialized via chezmoi; see `newsecret` helper in #13 for rotation flows).


### PR DESCRIPTION
## Summary

Materializes Catalog A (SSH identities) and Catalog B (AWS long-lived profiles) as in-repo documents under `docs/`. Unblocks wave-2b issues #11 and #12, which previously referenced `Catalog Section A` / `Catalog Section B` that had no backing text.

Catalogs ship with `Status: placeholder` and `TODO(BJ)` rows — BJ fills them in a follow-up before wave-2b executes. Issues #11 and #12 explicitly refuse to run on placeholder catalogs.

## Changes

- **NEW** `docs/catalog-a-ssh-identities.md` — per-identity schema (identity name, template file, VW item, key type, Host block, match pattern, purpose) with 6 skeleton rows (`id_ed25519`, `blueshift_{dev,test,prod}`, `{analogic,waveeng}_gitlab`) populated with TODO placeholders for the fields only BJ knows.
- **NEW** `docs/catalog-b-aws-profiles.md` — per-profile schema (profile name, VW item, region default, purpose) with `default` skeleton row + instruction to close #12 if no long-lived profiles exist (SSO-only case).
- **MODIFIED** `docs/beget-devspec.md` — R-17 and R-18 now point at the catalog files.
- **MODIFIED (via gh API, not code)** issues #11 and #12 — Changes sections rewritten to read from the catalog files and refuse TODO rows; Dependencies updated to block on #55.

## Linked Issues

Closes #55

## Test Plan

- [x] `docs/catalog-a-ssh-identities.md` renders in GitHub's markdown preview.
- [x] `docs/catalog-b-aws-profiles.md` renders in GitHub's markdown preview.
- [x] Dev Spec link updates verified by `grep` — 4 changes, 2 sections.
- [x] Issues #11 and #12 updated on GitHub (visible via `gh issue view 11` / `12`).
- [ ] BJ fills in actual rows before re-running `/wavemachine` (follow-up, not part of this PR).

## Follow-Up

After merge, BJ edits the catalog rows (concrete identity names, VW item names, Host patterns, AWS profiles) on a separate branch, flips `Status: placeholder → filled`, and re-invokes `/wavemachine`. The worker will resume from wave-2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)