### PR TITLE
docs(catalog): backfill A fully and B inventory from sketchbook

### DIFF
--- a/docs/catalog-a-ssh-identities.md
+++ b/docs/catalog-a-ssh-identities.md
@@ -1,6 +1,6 @@
 # Catalog A — SSH Identities
 
-**Status:** `placeholder` — BJ fills in rows before wave-2b (#11) executes.
+**Status:** `filled` (backfilled 2026-04-20 from `~/sysadmin/unresolved-issues/beget-sketchbook.md` §A).
 
 Materialized form of Dev Spec R-17: the SSH private keys that `chezmoi apply`
 materializes under `~/.ssh/`. One row per identity. Agents implementing #11
@@ -20,26 +20,53 @@ read this file; they do not infer or invent entries.
 
 ## Identities
 
-<!--
-  Fill in concrete rows below. Remove the TODO(BJ) markers when complete.
-  When this table has no TODO(BJ) rows, flip Status above to `filled`.
--->
+Identity names follow the sketchbook's planned rename scheme: `id_ed25519_<scope>`.
+This keeps the key type visible in the filename and makes future rotations
+(e.g. moving the legacy RSA key — see footnote) mechanical.
+
+**Source provenance (important for #11 agents — do not re-derive from malory today):**
+
+- **Identity names** come from sketchbook §"SSH architecture" / keys list (lines
+  230-234 of `~/sysadmin/unresolved-issues/beget-sketchbook.md`) plus the rename
+  plan in §A "SSH keys and identities" (lines 375-389).
+- **Host blocks and match patterns for blueshift rows** come from the sketchbook's
+  planned `~/.ssh/config` example (lines 240-253), not from malory's current
+  `~/.ssh/config`. Malory currently uses literal host aliases (`perkollate-dev`,
+  `perkollate-test`, `perkollate-prod`); the beget-managed config migrates to
+  wildcard-domain matching as documented in the sketchbook. Agents should emit
+  the wildcard form shown here, not the legacy aliases.
+- **Host blocks for GitLab rows** match today's malory config exactly
+  (`gitlab.com` literal, and the `gitlab-waveeng` alias that points at
+  `gitlab.com` with its own key).
 
 | Identity | Template file | VW item | Key type | Host block | Match pattern | Purpose |
 |---|---|---|---|---|---|---|
-| `id_ed25519`            | `private_id_ed25519.tmpl`            | `ssh-id-ed25519`            | ed25519 | TODO(BJ) | TODO(BJ) | Default personal key |
-| `blueshift_dev`         | `private_blueshift_dev.tmpl`         | `ssh-blueshift-dev`         | TODO(BJ) | TODO(BJ) | TODO(BJ) | Blueshift dev env |
-| `blueshift_test`        | `private_blueshift_test.tmpl`        | `ssh-blueshift-test`        | TODO(BJ) | TODO(BJ) | TODO(BJ) | Blueshift test env |
-| `blueshift_prod`        | `private_blueshift_prod.tmpl`        | `ssh-blueshift-prod`        | TODO(BJ) | TODO(BJ) | TODO(BJ) | Blueshift prod env |
-| `analogic_gitlab`       | `private_analogic_gitlab.tmpl`       | `ssh-analogic-gitlab`       | TODO(BJ) | TODO(BJ) | TODO(BJ) | Analogic GitLab |
-| `waveeng_gitlab`        | `private_waveeng_gitlab.tmpl`        | `ssh-waveeng-gitlab`        | TODO(BJ) | TODO(BJ) | TODO(BJ) | Wave Engineering GitLab |
+| `id_ed25519`                      | `private_id_ed25519.tmpl`                      | `ssh-id-ed25519`                      | ed25519 | `Host *`                    | `*` (catch-all default) | Primary personal identity (homelab SSH, general) |
+| `id_ed25519_analogic_gitlab`      | `private_id_ed25519_analogic_gitlab.tmpl`      | `ssh-id-ed25519-analogic-gitlab`      | ed25519 | `Host gitlab.com`           | `gitlab.com`            | Analogic GitLab identity (renamed from `gitlab.id_ed25519`) |
+| `id_ed25519_waveeng_gitlab`       | `private_id_ed25519_waveeng_gitlab.tmpl`       | `ssh-id-ed25519-waveeng-gitlab`       | ed25519 | `Host gitlab-waveeng`       | `gitlab-waveeng` (alias → `gitlab.com`) | Personal / Oak & Wave GitLab identity (renamed from `gitlab-waveeng.id_ed25519`) |
+| `id_ed25519_blueshift_dev`        | `private_id_ed25519_blueshift_dev.tmpl`        | `ssh-id-ed25519-blueshift-dev`        | ed25519 | `Host *.dev.blueshift.plus` | `*.dev.blueshift.plus`  | Blueshift dev env (renamed from `perkollate-dev`) |
+| `id_ed25519_blueshift_test`       | `private_id_ed25519_blueshift_test.tmpl`       | `ssh-id-ed25519-blueshift-test`       | ed25519 | `Host *.test.blueshift.plus`| `*.test.blueshift.plus` | Blueshift test env (renamed from `perkollate-test`) |
+| `id_ed25519_blueshift_prod`       | `private_id_ed25519_blueshift_prod.tmpl`       | `ssh-id-ed25519-blueshift-prod`       | ed25519 | `Host *.blueshift.plus`     | `*.blueshift.plus` — **greedy; must come last among blueshift rules** | Blueshift prod env (renamed from `perkollate-prod`) |
+
+**Footnote — `id_rsa` rotation (not in this catalog).** Malory currently has a
+legacy `~/.ssh/id_rsa` (RSA) paired with the `blueshift-dev` host block
+(3.214.20.90). The sketchbook flags this as "TODO: rotate to ed25519?" — a
+separate concern tracked outside this catalog. When rotated, it'll either
+replace `id_ed25519_blueshift_dev` (if same host) or get its own row.
 
 ## `~/.ssh/config` ordering
 
 `~/.ssh/config` matches first-win per block. Order rows in `config.tmpl`
-most-specific-first: explicit hostname blocks before wildcards, wildcards
-before the `Host *` default. Agents implementing #11 should preserve the
-order declared in the table above.
+most-specific-first:
+
+1. Explicit hostnames and aliases (`gitlab.com`, `gitlab-waveeng`).
+2. Narrow wildcards (`*.dev.blueshift.plus`, `*.test.blueshift.plus`).
+3. **Greedy wildcards last** — `*.blueshift.plus` matches everything under
+   `blueshift.plus` including `*.dev.` and `*.test.`, so it must come after
+   the narrower dev/test blocks or it shadows them.
+4. `Host *` catch-all default at the very end.
+
+Agents implementing #11 should preserve the order declared in the table above.
 
 ## Adding a new identity
 

--- a/docs/catalog-b-aws-profiles.md
+++ b/docs/catalog-b-aws-profiles.md
@@ -1,6 +1,8 @@
 # Catalog B — AWS Profiles (long-lived credentials)
 
-**Status:** `placeholder` — BJ fills in rows before wave-2b (#12) executes.
+**Status:** `placeholder` — profile inventory backfilled 2026-04-20 from
+`~/sysadmin/unresolved-issues/beget-sketchbook.md` §B. 8 of 9 profiles still
+need BJ's long-lived-vs-SSO disposition before wave-2b (#12) can execute.
 
 Materialized form of Dev Spec R-18: profiles in `~/.aws/credentials` that
 `chezmoi apply` renders from Vaultwarden items. One row per profile. Agents
@@ -23,20 +25,53 @@ Only **long-lived-credential** profiles belong here. Session/SSO profiles
 | **Region default** | Default region for the profile (`us-east-1`, etc.). Goes into `~/.aws/config`, not `credentials`, but listed here for completeness. |
 | **Purpose** | One-line description of what the profile is used for. Optional but recommended. |
 
-## Profiles
+## Profile inventory (from sketchbook §B)
 
-<!--
-  Fill in concrete rows below. Remove the TODO(BJ) markers when complete.
-  When this table has no TODO(BJ) rows, flip Status above to `filled`.
--->
+All AWS CLI profiles currently declared in malory's `~/.aws/config`. Each
+needs a disposition before it can be promoted into the long-lived-credentials
+table below. Fields BJ still needs to fill: **Disposition**, and for
+long-lived profiles, **Purpose** (one line).
+
+| Profile | Disposition | Purpose |
+|---|---|---|
+| `default`         | TODO(BJ) long-lived or SSO? | TODO(BJ) — personal-account default |
+| `bedrock`         | TODO(BJ) long-lived or SSO? | TODO(BJ) |
+| `bedrock-sync`    | TODO(BJ) long-lived or SSO? | TODO(BJ) |
+| `alog-admin`      | **SSO** — not materialized by chezmoi; lives in `~/.aws/config` only | Analogic admin access via IAM Identity Center (sso-session paired) |
+| `aws-admin`       | TODO(BJ) long-lived or SSO? | TODO(BJ) |
+| `s3-mgmt-bot`     | TODO(BJ) long-lived or SSO? | TODO(BJ) — S3 management automation |
+| `test-deploy-bot` | TODO(BJ) long-lived or SSO? | TODO(BJ) — test-env deploy automation |
+| `dev-deploy-bot`  | TODO(BJ) long-lived or SSO? | TODO(BJ) — dev-env deploy automation |
+| `prod-deploy-bot` | TODO(BJ) long-lived or SSO? | TODO(BJ) — prod-env deploy automation |
+
+Once each profile is classified, move long-lived ones into the
+**Long-lived credentials** table below and strike them from the
+inventory row count. The `alog-admin` SSO row stays here for
+completeness (explicitly out of scope for this catalog — see Scope above).
+
+## Long-lived credentials
+
+Profiles with long-lived static credentials (materialized by chezmoi from
+Vaultwarden). Populated from the inventory above as BJ classifies each
+profile. Until the inventory has 0 TODO rows, **Status** at the top of this
+file remains `placeholder` and agents implementing #12 should refuse to
+execute.
 
 | Profile | VW item | Region default | Purpose |
 |---|---|---|---|
-| `default` | `aws-default` | TODO(BJ) | TODO(BJ) — personal-account default |
+| _(empty — awaiting BJ dispositions in inventory above)_ | — | — | — |
 
-TODO(BJ): add a row per long-lived profile. If there are *no* long-lived
-profiles (i.e. you only use SSO), say so here and issue #12 should be
-closed as not-applicable rather than implemented.
+**Conventions (to apply when populating rows):**
+
+- VW item name is `aws-<profile>` (e.g. `aws-default`, `aws-s3-mgmt-bot`),
+  with `username = AccessKeyId`, `password = SecretAccessKey` — per sketchbook
+  lines 273-277.
+- Region default is `us-east-1` unless the profile needs otherwise
+  (sketchbook line 440: `AWS_REGION=us-east-1` is the non-secret global
+  default); override per profile in `~/.aws/config` if needed.
+
+No row is added to this table until its disposition in the inventory above
+flips from `TODO(BJ)` to `long-lived`. SSO profiles never appear here.
 
 ## `~/.aws/credentials` rendering order
 


### PR DESCRIPTION
## Summary

Backfills the placeholder SSH-identities and AWS-profiles catalogs (landed in #56) with the concrete inventory that already existed in `~/sysadmin/unresolved-issues/beget-sketchbook.md`. Narrows BJ's remaining fill-in work from ~30 TODO cells to 8 AWS long-lived-vs-SSO dispositions.

## Changes

- **`docs/catalog-a-ssh-identities.md`** — 6 rows fully populated (Key type=ed25519, Host blocks, match patterns, purposes). Status flipped `placeholder` → `filled`. Source-provenance block added citing sketchbook lines 230-234, 240-253, 375-389 so #11 agents know blueshift wildcard Host blocks come from the sketchbook's planned config (not invented, not malory's current legacy aliases). SSH config ordering section expanded to explain why greedy wildcards must come last. `id_rsa` rotation flagged as footnote (disposition TODO separate from this catalog).

- **`docs/catalog-b-aws-profiles.md`** — Profile inventory section added listing all 9 sketchbook profiles. `alog-admin` marked SSO (out of this catalog's scope). The other 8 carry `TODO(BJ) long-lived or SSO?` dispositions for BJ. Long-lived credentials table emptied with `_(empty — awaiting BJ dispositions)_` placeholder plus conventions block (VW `aws-<profile>`, region default `us-east-1`, sourced from sketchbook lines 273-277 and 440). Status stays `placeholder` until BJ classifies the 8 TODOs.

## Linked Issues

Closes #57

## Test Plan

- [x] `make lint` — shellcheck clean
- [x] `make test-unit` — 61/61 pass
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `grep -c "TODO(BJ)" docs/catalog-a-ssh-identities.md` → 0 (Status = filled, AC satisfied)
- [x] `grep -c "TODO(BJ)" docs/catalog-b-aws-profiles.md` → 9 (8 disposition rows + 1 prose reference in conventions; alog-admin has no TODO as expected)
- [x] All 9 sketchbook profiles present in Catalog B inventory
- [x] `feature-dev:code-reviewer` agent — 2 findings, both fixed in-branch before commit
- [x] Dev Spec R-17 / R-18 pointers to these catalogs unchanged

## Review findings (fixed in branch)

1. **Host-block provenance** — reviewer flagged that sketchbook §A shows literal aliases (`perkollate-dev`) while I used wildcard domains (`*.dev.blueshift.plus`). Fix: added explicit "Source provenance" section citing sketchbook lines 240-253 (the planned wildcard form, which is the chezmoi-materialized target) vs §A (malory's current legacy form, which is being migrated FROM).
2. **Pre-populated `default` row** — catalog B had `default` already in the long-lived credentials table with `aws-default` / `us-east-1`, but `default`'s disposition was still TODO above. A #12 agent reading only the long-lived table would treat it as settled. Fix: removed the row; replaced with explicit `_(empty — awaiting BJ dispositions)_` placeholder and moved the VW/region conventions into their own callout block.