### PR TITLE
chore(config): refresh .claude-project.md toolchain to match Makefile

### DIFF
--- a/.claude-project.md
+++ b/.claude-project.md
@@ -31,12 +31,12 @@ Project taxonomy (mutually exclusive within each `group::` prefix):
 - **wave::** `wave::1.1`, `wave::1.2`, `wave::1.3`, `wave::2.1`, `wave::2.2`, `wave::2.3`, `wave::2.4`, `wave::3.1`, `wave::3.2`, `wave::3.3`, `wave::3.4` (from Dev Spec Section 8)
 
 ## Toolchain
-- **Validation:** none
-- **Tests:** none
-- **Build:** none
-- **Lint:** none
+- **Validation:** `make lint` (shellcheck on `install.sh`, `lib/*.sh`, `run_onchange_*`)
+- **Tests:** `make test-unit` (bats-core via git submodule at `tests/bats`; bootstrap with `make bootstrap-test-deps`)
+- **Build:** n/a (chezmoi-driven; use `make apply-dry` to preview, `make apply` to render, `make verify` to detect drift)
+- **Lint:** shellcheck (invoked via `make lint`)
 
-No `Makefile`, `scripts/ci/`, `pyproject.toml`, `package.json`, `Cargo.toml`, or `go.mod` present. Project currently contains only `docs/` and planning artifacts — add toolchain here as it is introduced.
+`Makefile` is the canonical entry point (`make help` lists targets). No `pyproject.toml`, `package.json`, `Cargo.toml`, or `go.mod` — this is a bash + chezmoi-template project.
 
 ## CI
 - **System:** none


### PR DESCRIPTION
## Summary

Refresh the Toolchain section of `.claude-project.md` to match the actual build system. The file's cached values (`Validation: none`, `Tests: none`, `Build: none`, `Lint: none`) predate the `Makefile` that landed in PR #51, so the project config misreported the toolchain to every agent reading it at session start.

## Changes

- `.claude-project.md`: Toolchain section — replace the four `none` lines with real Make targets (`make lint`, `make test-unit`, `make apply-dry|apply|verify`), and update the trailing narrative line to describe the Makefile as the canonical entry point.

No other sections touched; no behavior change anywhere in the codebase.

## Linked Issues

Closes #61

## Test Plan

- `make lint` — green (shellcheck on `install.sh`, `lib/platform.sh`).
- `make test-unit` — 61/61 bats tests pass.
- `trivy fs --severity HIGH,CRITICAL` — 0 findings.
- Code review (`feature-dev:code-reviewer`) — clean; every target named in the new Toolchain block verified present in `Makefile`.