### PR TITLE
feat(ssh): SSH key chezmoi templates (Closes #11)

### DIFF
--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -1,0 +1,42 @@
+# ~/.ssh/config — managed by chezmoi via beget
+#
+# Host blocks are ordered most-specific-first (first-match wins). See
+# docs/catalog-a-ssh-identities.md for the authoritative identity list and
+# the rationale for this ordering. Agents implementing #11: do not reorder
+# without updating the catalog first.
+
+# ---- GitLab identities (explicit hostnames / aliases) -----------------------
+
+Host gitlab.com
+    HostName gitlab.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_analogic_gitlab
+    IdentitiesOnly yes
+
+Host gitlab-waveeng
+    HostName gitlab.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_waveeng_gitlab
+    IdentitiesOnly yes
+
+# ---- Blueshift environments (narrow wildcards first) -----------------------
+
+Host *.dev.blueshift.plus
+    IdentityFile ~/.ssh/id_ed25519_blueshift_dev
+    IdentitiesOnly yes
+
+Host *.test.blueshift.plus
+    IdentityFile ~/.ssh/id_ed25519_blueshift_test
+    IdentitiesOnly yes
+
+# Greedy wildcard — must come after the narrower dev/test blocks above so it
+# does not shadow them. Catches anything under blueshift.plus not matched
+# by the more specific rules.
+Host *.blueshift.plus
+    IdentityFile ~/.ssh/id_ed25519_blueshift_prod
+    IdentitiesOnly yes
+
+# ---- Catch-all default (primary personal identity) -------------------------
+
+Host *
+    IdentityFile ~/.ssh/id_ed25519

--- a/private_dot_ssh/private_id_ed25519.tmpl
+++ b/private_dot_ssh/private_id_ed25519.tmpl
@@ -1,0 +1,1 @@
+{{ (rbwFields "ssh-id-ed25519").privateKey.value }}

--- a/private_dot_ssh/private_id_ed25519_analogic_gitlab.tmpl
+++ b/private_dot_ssh/private_id_ed25519_analogic_gitlab.tmpl
@@ -1,0 +1,1 @@
+{{ (rbwFields "ssh-id-ed25519-analogic-gitlab").privateKey.value }}

--- a/private_dot_ssh/private_id_ed25519_blueshift_dev.tmpl
+++ b/private_dot_ssh/private_id_ed25519_blueshift_dev.tmpl
@@ -1,0 +1,1 @@
+{{ (rbwFields "ssh-id-ed25519-blueshift-dev").privateKey.value }}

--- a/private_dot_ssh/private_id_ed25519_blueshift_prod.tmpl
+++ b/private_dot_ssh/private_id_ed25519_blueshift_prod.tmpl
@@ -1,0 +1,1 @@
+{{ (rbwFields "ssh-id-ed25519-blueshift-prod").privateKey.value }}

--- a/private_dot_ssh/private_id_ed25519_blueshift_test.tmpl
+++ b/private_dot_ssh/private_id_ed25519_blueshift_test.tmpl
@@ -1,0 +1,1 @@
+{{ (rbwFields "ssh-id-ed25519-blueshift-test").privateKey.value }}

--- a/private_dot_ssh/private_id_ed25519_waveeng_gitlab.tmpl
+++ b/private_dot_ssh/private_id_ed25519_waveeng_gitlab.tmpl
@@ -1,0 +1,1 @@
+{{ (rbwFields "ssh-id-ed25519-waveeng-gitlab").privateKey.value }}


### PR DESCRIPTION
## Summary

Materialize SSH private keys via chezmoi+rbw templates per Catalog A. One `private_*.tmpl` per identity row, plus a rewritten `config.tmpl` with Host blocks in catalog order.

## Changes

- `private_dot_ssh/private_id_ed25519.tmpl` — primary personal identity
- `private_dot_ssh/private_id_ed25519_analogic_gitlab.tmpl` — analogic GitLab
- `private_dot_ssh/private_id_ed25519_waveeng_gitlab.tmpl` — waveeng GitLab (alias)
- `private_dot_ssh/private_id_ed25519_blueshift_dev.tmpl` — blueshift dev
- `private_dot_ssh/private_id_ed25519_blueshift_test.tmpl` — blueshift test
- `private_dot_ssh/private_id_ed25519_blueshift_prod.tmpl` — blueshift prod
- `private_dot_ssh/config.tmpl` — Host blocks ordered most-specific-first (GitLab → narrow wildcards → greedy `*.blueshift.plus` → `Host *` catch-all)

All templates reference rbw items via `rbwFields "<item>".privateKey.value` — R-10 compliant (no literal secrets). Chezmoi's `private_` prefix enforces 0600 per R-17.

## Linked Issues

Closes #11

## Test Plan

- [x] `make lint` — clean
- [x] 1:1 catalog mapping verified (6 rows → 6 templates)
- [x] Host block ordering preserves catalog order
- [ ] Post-merge manual verification: `chezmoi apply` renders all keys at 0600, `ssh-keygen -l` validates each file (requires VW items populated — R-17 runtime check)
