### PR TITLE
feat(aws): AWS credentials chezmoi template (Closes #12)

### DIFF
--- a/private_dot_aws/config
+++ b/private_dot_aws/config
@@ -1,0 +1,34 @@
+# ~/.aws/config — managed by chezmoi via beget
+#
+# Non-secret AWS CLI configuration. Per-profile region defaults live here;
+# long-lived credentials live in ~/.aws/credentials (rendered from
+# Vaultwarden — see private_dot_aws/credentials.tmpl).
+#
+# Catalog B lists all long-lived profiles at us-east-1. SSO / session
+# profiles (if any) get added below with `sso_session` references — they
+# are NOT materialized from Vaultwarden.
+
+[default]
+region = us-east-1
+output = json
+
+[profile aws-admin]
+region = us-east-1
+
+[profile bedrock]
+region = us-east-1
+
+[profile bedrock-sync]
+region = us-east-1
+
+[profile dev-deploy-bot]
+region = us-east-1
+
+[profile prod-deploy-bot]
+region = us-east-1
+
+[profile s3-mgmt-bot]
+region = us-east-1
+
+[profile test-deploy-bot]
+region = us-east-1

--- a/private_dot_aws/credentials.tmpl
+++ b/private_dot_aws/credentials.tmpl
@@ -1,0 +1,44 @@
+# ~/.aws/credentials — managed by chezmoi via beget
+#
+# Long-lived credentials only. See docs/catalog-b-aws-profiles.md for the
+# authoritative profile list. SSO / session profiles live in
+# ~/.aws/config and are not materialized from Vaultwarden.
+#
+# VW convention (catalog B, §Conventions encoded above):
+#   username = AccessKeyId, password = SecretAccessKey
+#
+# Rendering order: `default` first, then alphabetical. Agents implementing
+# #12 follow the order declared in the catalog's "Long-lived credentials"
+# table — do not reorder without updating the catalog first.
+
+[default]
+aws_access_key_id = {{ (rbw "aws-default").data.username }}
+aws_secret_access_key = {{ (rbw "aws-default").data.password }}
+
+[aws-admin]
+aws_access_key_id = {{ (rbw "aws-aws-admin").data.username }}
+aws_secret_access_key = {{ (rbw "aws-aws-admin").data.password }}
+
+[bedrock]
+aws_access_key_id = {{ (rbw "aws-bedrock").data.username }}
+aws_secret_access_key = {{ (rbw "aws-bedrock").data.password }}
+
+[bedrock-sync]
+aws_access_key_id = {{ (rbw "aws-bedrock-sync").data.username }}
+aws_secret_access_key = {{ (rbw "aws-bedrock-sync").data.password }}
+
+[dev-deploy-bot]
+aws_access_key_id = {{ (rbw "aws-dev-deploy-bot").data.username }}
+aws_secret_access_key = {{ (rbw "aws-dev-deploy-bot").data.password }}
+
+[prod-deploy-bot]
+aws_access_key_id = {{ (rbw "aws-prod-deploy-bot").data.username }}
+aws_secret_access_key = {{ (rbw "aws-prod-deploy-bot").data.password }}
+
+[s3-mgmt-bot]
+aws_access_key_id = {{ (rbw "aws-s3-mgmt-bot").data.username }}
+aws_secret_access_key = {{ (rbw "aws-s3-mgmt-bot").data.password }}
+
+[test-deploy-bot]
+aws_access_key_id = {{ (rbw "aws-test-deploy-bot").data.username }}
+aws_secret_access_key = {{ (rbw "aws-test-deploy-bot").data.password }}


### PR DESCRIPTION
## Summary

Render `~/.aws/credentials` from Vaultwarden via chezmoi templates per Catalog B. All 8 long-lived profiles in catalog order (default first, then alphabetical). Adds a static `config` with per-profile region defaults.

## Changes

- `private_dot_aws/credentials.tmpl` — rbw-templated long-lived creds for all 8 profiles (default, aws-admin, bedrock, bedrock-sync, dev-deploy-bot, prod-deploy-bot, s3-mgmt-bot, test-deploy-bot)
- `private_dot_aws/config` — region defaults (us-east-1 per catalog) per profile

VW convention per catalog §Conventions: `username = AccessKeyId`, `password = SecretAccessKey`. Chezmoi's `private_` prefix enforces 0600 per R-18.

## Linked Issues

Closes #12

## Test Plan

- [x] `make lint` — clean
- [x] 1:1 catalog mapping verified (8 rows → 8 profile blocks)
- [x] Rendering order matches catalog (default first, then alphabetical)
- [ ] Post-merge manual verification: `chezmoi apply` renders `~/.aws/credentials` at 0600, `aws --profile <X> sts get-caller-identity` succeeds for each profile (requires VW items populated)
