### PR TITLE
feat(newsecret): user-facing Vaultwarden add helper (Closes #13)

### DIFF
--- a/dot_local/bin/executable_newsecret
+++ b/dot_local/bin/executable_newsecret
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# ~/.local/bin/newsecret — managed by chezmoi via beget
+#
+# User-facing helper for adding secrets to Vaultwarden via `rbw`.
+#
+# Usage:
+#   newsecret <name>
+#
+# Reads the secret value from stdin (prompted on a TTY). Validates that
+# <name> is a sensible rbw item name and that no item by that name
+# already exists. Creates a VW Login item with the secret as its
+# password field, then reports the derived shell-env-var name per
+# R-15 (dashes → underscores, upper-cased).
+#
+# Exit codes:
+#   0  success (item created)
+#   1  usage / validation error
+#   2  rbw add failed
+#
+# Test seams (env-var overrides):
+#   BEGET_RBW_CMD     name of the rbw binary (default: rbw).
+#
+# References: R-15, S2.4 (bakeb7j0/beget#13).
+
+set -euo pipefail
+
+BEGET_RBW_CMD="${BEGET_RBW_CMD:-rbw}"
+
+usage() {
+    printf 'usage: newsecret <item-name>\n' >&2
+    printf '\n' >&2
+    printf '  Read a secret value from stdin and add it to Vaultwarden as\n' >&2
+    printf '  a Login item named <item-name> (password field).\n' >&2
+}
+
+die() {
+    printf 'newsecret: %s\n' "$*" >&2
+    exit 1
+}
+
+# ---- Arg validation --------------------------------------------------------
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 1
+fi
+
+name="$1"
+
+if [[ -z "$name" ]]; then
+    die "item name must not be empty"
+fi
+
+# Reject whitespace anywhere in the name.
+if [[ "$name" =~ [[:space:]] ]]; then
+    die "item name must not contain whitespace: '$name'"
+fi
+
+# ---- Duplicate check -------------------------------------------------------
+# rbw get exits non-zero when the item is missing; zero when present. We
+# want missing for the happy path. Capture stderr silently so the user
+# sees only our message.
+if "$BEGET_RBW_CMD" get "$name" >/dev/null 2>&1; then
+    die "item '$name' already exists in Vaultwarden (use \`rbw edit\` to update)"
+fi
+
+# ---- Prompt + read value ---------------------------------------------------
+# When stdin is a TTY, prompt interactively without echoing. When stdin is
+# a pipe, read the first line non-interactively (for scripts and tests).
+value=""
+if [[ -t 0 ]]; then
+    printf 'Value for %s (input hidden): ' "$name" >&2
+    # -s silent, -r preserve backslashes. Allow EOF (empty input) without
+    # tripping set -e; the empty-value check below handles the error.
+    IFS= read -rs value || true
+    printf '\n' >&2
+else
+    IFS= read -r value || true
+fi
+
+if [[ -z "$value" ]]; then
+    die "secret value must not be empty"
+fi
+
+# ---- Create the item -------------------------------------------------------
+# rbw add <name> reads the value from stdin. Pipe the value in so the
+# user does not get prompted again.
+if ! printf '%s' "$value" | "$BEGET_RBW_CMD" add "$name" >/dev/null 2>&1; then
+    printf 'newsecret: rbw add failed for %s\n' "$name" >&2
+    exit 2
+fi
+
+# ---- Derive and report env-var name (R-15 inverse) -------------------------
+# name: lowercase with dashes  →  env var: uppercase with underscores.
+env_var="${name//-/_}"
+env_var="${env_var^^}"
+
+printf 'created Vaultwarden item: %s\n' "$name"
+# shellcheck disable=SC2016
+# Intent: print the literal text '$FOO' to the user — not expand it.
+printf 'shell env var (via `secret`): $%s\n' "$env_var"

--- a/tests/unit/newsecret.bats
+++ b/tests/unit/newsecret.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# tests/unit/newsecret.bats — unit tests for dot_local/bin/executable_newsecret
+#
+# Strategy: swap BEGET_RBW_CMD to a shim script under BATS_TEST_TMPDIR so
+# rbw calls are deterministic. Drive newsecret with piped stdin (the
+# non-TTY branch) so the tests can assert on exit codes and output.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    NEWSECRET="$REPO_ROOT/dot_local/bin/executable_newsecret"
+
+    SHIM_DIR="$BATS_TEST_TMPDIR/shim"
+    mkdir -p "$SHIM_DIR"
+    export BEGET_RBW_CMD="$SHIM_DIR/rbw"
+
+    # Record file so we can assert what rbw was called with and what
+    # stdin it received.
+    export SHIM_LOG="$BATS_TEST_TMPDIR/rbw-calls.log"
+    : >"$SHIM_LOG"
+}
+
+# Helper: install an rbw shim with a given `get` behavior.
+#   $1 = get-behavior: missing (exit 1) | present (exit 0)
+#   $2 = add-behavior: ok (exit 0) | fail (exit 1)
+make_rbw() {
+    local get_behavior="$1"
+    local add_behavior="${2:-ok}"
+
+    cat >"$BEGET_RBW_CMD" <<EOF
+#!/usr/bin/env bash
+# Fake rbw shim for newsecret tests.
+sub="\${1:-}"
+item="\${2:-}"
+case "\$sub" in
+  get)
+    echo "get \$item" >>"$SHIM_LOG"
+    case "$get_behavior" in
+      missing) exit 1 ;;
+      present) echo "existing-value"; exit 0 ;;
+    esac
+    ;;
+  add)
+    # Capture the item name plus the piped value.
+    value="\$(cat)"
+    echo "add \$item value=\$value" >>"$SHIM_LOG"
+    case "$add_behavior" in
+      ok)   exit 0 ;;
+      fail) echo "rbw add: synthetic failure" >&2; exit 1 ;;
+    esac
+    ;;
+  *)
+    echo "unexpected rbw subcommand: \$sub" >&2
+    exit 99
+    ;;
+esac
+EOF
+    chmod +x "$BEGET_RBW_CMD"
+}
+
+# ---- Argument / usage validation -------------------------------------------
+
+@test "no-arg usage prints usage and exits 1" {
+    make_rbw missing ok
+    run "$NEWSECRET"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"usage: newsecret"* ]]
+}
+
+@test "too-many args exits 1" {
+    make_rbw missing ok
+    run "$NEWSECRET" foo bar
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"usage: newsecret"* ]]
+}
+
+@test "whitespace in name is rejected" {
+    make_rbw missing ok
+    run bash -c "printf 'val\n' | '$NEWSECRET' 'has space'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"whitespace"* ]]
+}
+
+# ---- Duplicate detection ---------------------------------------------------
+
+@test "duplicate name reports clear error" {
+    make_rbw present ok
+    run bash -c "printf 'val\n' | '$NEWSECRET' existing-item"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"already exists"* ]]
+    [[ "$output" == *"existing-item"* ]]
+}
+
+# ---- Empty-value rejection -------------------------------------------------
+
+@test "empty stdin value is rejected" {
+    make_rbw missing ok
+    run bash -c "printf '' | '$NEWSECRET' new-item"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must not be empty"* ]]
+}
+
+# ---- Happy path ------------------------------------------------------------
+
+@test "happy path: rbw add called with piped value; derived env var reported" {
+    make_rbw missing ok
+    run bash -c "printf 'super-secret-value\n' | '$NEWSECRET' github-pat"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"created Vaultwarden item: github-pat"* ]]
+    [[ "$output" == *"\$GITHUB_PAT"* ]]
+
+    # Shim recorded an add call for the right name with the right value.
+    grep -q "^add github-pat value=super-secret-value$" "$SHIM_LOG"
+}
+
+@test "env var derivation: multi-dash name becomes upper underscores" {
+    make_rbw missing ok
+    run bash -c "printf 'v\n' | '$NEWSECRET' analogic-gitlab-token"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\$ANALOGIC_GITLAB_TOKEN"* ]]
+}
+
+# ---- rbw add failure -------------------------------------------------------
+
+@test "rbw add failure propagates exit 2" {
+    make_rbw missing fail
+    run bash -c "printf 'v\n' | '$NEWSECRET' doomed-item"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"rbw add failed"* ]]
+}


### PR DESCRIPTION
## Summary

`newsecret <item>` validates the item name, rejects duplicates, reads a secret from stdin (with interactive `-s` prompt on TTY), rejects empty values, pipes to `rbw add`, and reports the derived R-15-style env-var name.

## Changes

- `dot_local/bin/executable_newsecret` — bash helper (uses BEGET_RBW_CMD test seam consistent with wrappers.sh)
- `tests/unit/newsecret.bats` — 8 unit tests exercising every AC path via a hermetic rbw shim

## Linked Issues

Closes #13

## Test Plan

- [x] `make test-unit` — 69/69 green (61 existing + 8 new)
- [x] `shellcheck dot_local/bin/executable_newsecret` — clean (one justified SC2016 disable for the intentional literal `$FOO` output)
- [x] AC coverage: no-arg exit 1, duplicate error, empty stdin rejected, VW Login created (shim verifies `rbw add` called with piped value), env-var name reported, rbw add failure → exit 2
