### PR TITLE
docs(spec): replace dangling Catalog K/L references in Dev Spec ACs

### DIFF
--- a/docs/beget-devspec.md
+++ b/docs/beget-devspec.md
@@ -1022,7 +1022,7 @@ Testing a machine-bootstrap project has structural challenges: CI can't spin up 
 
 **Acceptance criteria**:
 - [ ] common.list ≥20 base packages
-- [ ] workstation.list covers GUI/desktop from Catalog K
+- [ ] workstation.list covers GUI/desktop categories (browsers, editors/IDEs, messaging, media, fonts)
 - [ ] Script runs `apt-get install -y` on Ubuntu; equivalent on RHEL
 - [ ] Role scoping: minimal installs only minimal; workstation installs common + workstation
 - [ ] Idempotent
@@ -1105,7 +1105,7 @@ Testing a machine-bootstrap project has structural challenges: CI can't spin up 
 **Test procedures**: IT-01 per script, E2E-04 (binary --version).
 
 **Acceptance criteria**:
-- [ ] Every Catalog L binary has install script
+- [ ] Every binary listed in implementation steps 1-7 has an install script
 - [ ] Each documents source, version, checksum
 - [ ] Idempotent (skips correct-version installs)
 - [ ] Fails clean on 404/checksum mismatch


### PR DESCRIPTION
## Summary

Stories #18 (S3.1 APT Package Lists) and #22 (S3.2 Non-apt Tooling) had acceptance criteria referencing "Catalog K" and "Catalog L" that were never authored — only catalogs A (SSH) and B (AWS) exist. The ACs were unevaluable and `/wavemachine` aborted at the wave-3a pre-flight drift check.

This edit rewrites both ACs to describe the target content inline, drawing from the same stories' implementation steps (§1014-1018 for #18, §1096-1103 for #22) which already enumerate the packages and binaries being installed. No new catalog files needed; the spec now stands on its own.

## Changes

- `docs/beget-devspec.md:1025` — `workstation.list covers GUI/desktop from Catalog K` → `workstation.list covers GUI/desktop categories (browsers, editors/IDEs, messaging, media, fonts)`
- `docs/beget-devspec.md:1108` — `Every Catalog L binary has install script` → `Every binary listed in implementation steps 1-7 has an install script`

## Linked Issues

Closes #70

## Test Plan

- [x] `grep -n "Catalog K\|Catalog L" docs/beget-devspec.md` returns no matches
- [x] `make lint` — shellcheck clean
- [x] `make test-unit` — 96/96 passing
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] Code review — no findings on this diff (1 out-of-scope observation re: dangling `Catalog Section E/H` refs in the requirements section, tracked for a follow-up)
- [ ] Post-merge: `/wavemachine` pre-flight for wave-3a passes