### PR TITLE
feat(packages): role-scoped APT package lists + install hook

### DIFF
--- a/run_onchange_before_20-packages-common.sh
+++ b/run_onchange_before_20-packages-common.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# run_onchange_before_20-packages-common.sh — install role-scoped package lists.
+#
+# chezmoi `run_onchange_before_*` hook: chezmoi invokes this script when its
+# contents change. We therefore include the hash of every list file we read
+# (via the chezmoi `sha256sum` template below) so edits to any list trigger a
+# re-install. The script itself is role-agnostic: it inspects BEGET_ROLE (or
+# derives it from chezmoi data) and installs the matching role's packages.
+#
+# Roles:
+#   minimal     → installs only apt-packages-minimal.list (no common)
+#   server      → installs common + server
+#   workstation → installs common + workstation
+#   (default)   → installs common only
+#
+# Idempotency: the underlying `pkg_install` delegates to `apt-get install -y`
+# or `dnf install -y`, both of which are no-ops when the package is already at
+# the requested version.
+#
+# Test seams (env-var overrides):
+#   BEGET_ROLE           — role selector (default: workstation)
+#   BEGET_PACKAGE_DIR    — directory containing apt-packages-*.list
+#                          (default: $HOME/.local/share/beget)
+#   BEGET_PKG_INSTALL    — function name to invoke (default: pkg_install)
+#                          override allows unit tests to capture invocations.
+#
+# chezmoi injects the following hashes so this script re-runs on any list edit:
+#   common:      {{ include "share/apt-packages-common.list" | sha256sum }}
+#   workstation: {{ include "share/apt-packages-workstation.list" | sha256sum }}
+#   server:      {{ include "share/apt-packages-server.list" | sha256sum }}
+#   minimal:     {{ include "share/apt-packages-minimal.list" | sha256sum }}
+
+set -euo pipefail
+
+REPO_LIB_DIR="${BEGET_LIB_DIR:-${HOME}/.local/share/beget/lib}"
+PACKAGE_DIR="${BEGET_PACKAGE_DIR:-${HOME}/.local/share/beget}"
+ROLE="${BEGET_ROLE:-workstation}"
+
+# Source lib/platform.sh for pkg_install. In production chezmoi lays this file
+# out under ~/.local/share/beget/lib/platform.sh; tests override BEGET_LIB_DIR.
+if [[ -r "${REPO_LIB_DIR}/platform.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${REPO_LIB_DIR}/platform.sh"
+fi
+
+# Read a package list file and emit one package name per line, skipping blank
+# lines and `#` comment lines. Leading/trailing whitespace is stripped so that
+# list formatting (indentation, tabs) does not affect package names.
+read_list() {
+    local list_file="$1"
+    # awk handles whitespace stripping and comment filtering in a single pass.
+    awk '
+        {
+            sub(/#.*/, "")          # drop inline comments
+            gsub(/^[ \t]+|[ \t]+$/, "")
+            if (length($0) > 0) print
+        }
+    ' "$list_file"
+}
+
+# Install every package named in the given list file, if the file exists.
+install_from_list() {
+    local list_file="$1"
+    if [[ ! -r "$list_file" ]]; then
+        printf 'run_onchange_before_20-packages-common: skip missing list %s\n' "$list_file" >&2
+        return 0
+    fi
+
+    local -a pkgs=()
+    while IFS= read -r pkg; do
+        pkgs+=("$pkg")
+    done < <(read_list "$list_file")
+
+    if [[ ${#pkgs[@]} -eq 0 ]]; then
+        printf 'run_onchange_before_20-packages-common: %s is empty, nothing to install\n' "$list_file" >&2
+        return 0
+    fi
+
+    local installer="${BEGET_PKG_INSTALL:-pkg_install}"
+    "$installer" "${pkgs[@]}"
+}
+
+main() {
+    local common_list="${PACKAGE_DIR}/apt-packages-common.list"
+    local role_list="${PACKAGE_DIR}/apt-packages-${ROLE}.list"
+
+    case "$ROLE" in
+        minimal)
+            # minimal role gets only the survival-kit list, NOT common.
+            install_from_list "${PACKAGE_DIR}/apt-packages-minimal.list"
+            ;;
+        workstation|server)
+            install_from_list "$common_list"
+            install_from_list "$role_list"
+            ;;
+        *)
+            printf 'run_onchange_before_20-packages-common: unknown role %s, installing common only\n' "$ROLE" >&2
+            install_from_list "$common_list"
+            ;;
+    esac
+}
+
+main "$@"

--- a/share/apt-packages-common.list
+++ b/share/apt-packages-common.list
@@ -1,0 +1,46 @@
+# share/apt-packages-common.list — base dev CLIs installed on every role.
+#
+# One package name per line. Blank lines and lines starting with `#` are ignored.
+# Keep entries alphabetized within each category block.
+
+# --- version control ---
+git
+git-lfs
+
+# --- shells & terminal ---
+bash
+bash-completion
+tmux
+
+# --- core CLI utilities ---
+ca-certificates
+curl
+jq
+less
+man-db
+rsync
+tree
+unzip
+wget
+zip
+
+# --- search / navigation ---
+fd-find
+fzf
+ripgrep
+
+# --- networking diagnostics ---
+dnsutils
+iproute2
+netcat-openbsd
+
+# --- build + scripting basics ---
+build-essential
+make
+python3
+python3-pip
+python3-venv
+
+# --- shell linting + container tooling ---
+docker.io
+shellcheck

--- a/share/apt-packages-minimal.list
+++ b/share/apt-packages-minimal.list
@@ -1,0 +1,10 @@
+# share/apt-packages-minimal.list — bare-metal survival kit.
+#
+# Used on the `minimal` role ONLY (containers, CI runners, headless VMs).
+# Installed instead of the common list. One package per line;
+# blank lines and `#` comments ignored.
+
+bash
+ca-certificates
+curl
+git

--- a/share/apt-packages-server.list
+++ b/share/apt-packages-server.list
@@ -1,0 +1,20 @@
+# share/apt-packages-server.list — server-focused packages for the server role.
+#
+# Installed IN ADDITION TO the common list on server-tagged machines.
+# One package per line; blank lines and `#` comments ignored.
+
+# --- daemon management / observability ---
+htop
+iftop
+iotop
+lsof
+sysstat
+
+# --- networking services ---
+chrony
+nftables
+openssh-server
+
+# --- filesystem / storage ---
+parted
+smartmontools

--- a/share/apt-packages-workstation.list
+++ b/share/apt-packages-workstation.list
@@ -1,0 +1,24 @@
+# share/apt-packages-workstation.list — GUI/desktop packages for workstation role.
+#
+# Installed IN ADDITION TO the common list on workstation-tagged machines.
+# One package per line; blank lines and `#` comments ignored.
+
+# --- browsers ---
+chromium-browser
+firefox
+
+# --- editors / IDEs ---
+neovim
+vim-gtk3
+
+# --- messaging / collaboration ---
+thunderbird
+
+# --- media ---
+mpv
+vlc
+
+# --- fonts ---
+fonts-firacode
+fonts-noto
+fonts-noto-color-emoji

--- a/tests/unit/apt-packages.bats
+++ b/tests/unit/apt-packages.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# tests/unit/apt-packages.bats — unit tests for
+# run_onchange_before_20-packages-common.sh and the share/apt-packages-*.list
+# files.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/run_onchange_before_20-packages-common.sh"
+
+    # Isolate PACKAGE_DIR into a temp dir so tests can stage list files.
+    export BEGET_PACKAGE_DIR="$BATS_TEST_TMPDIR/packages"
+    mkdir -p "$BEGET_PACKAGE_DIR"
+
+    # Capture installer invocations by overriding the install function name.
+    # The script will call `test_pkg_install <pkg>...`; we export a definition
+    # that appends to a file so tests can assert argv.
+    export BEGET_PKG_INSTALL="test_pkg_install"
+    export BEGET_INSTALL_LOG="$BATS_TEST_TMPDIR/install.log"
+    : > "$BEGET_INSTALL_LOG"
+    test_pkg_install() {
+        printf 'CALL:'
+        printf ' %s' "$@"
+        printf '\n'
+    }
+    export -f test_pkg_install
+}
+
+# --- list file content ------------------------------------------------------
+
+@test "apt-packages-common.list has at least 20 non-comment entries" {
+    local list="$REPO_ROOT/share/apt-packages-common.list"
+    [ -r "$list" ]
+    local count
+    count=$(grep -cv '^\s*\(#\|$\)' "$list")
+    [ "$count" -ge 20 ]
+}
+
+@test "apt-packages-workstation.list covers GUI/desktop categories" {
+    local list="$REPO_ROOT/share/apt-packages-workstation.list"
+    [ -r "$list" ]
+    # Dev Spec AC: browsers, editors/IDEs, messaging, media, fonts.
+    grep -q '# --- browsers ---' "$list"
+    grep -q '# --- editors / IDEs ---' "$list"
+    grep -q '# --- messaging' "$list"
+    grep -q '# --- media ---' "$list"
+    grep -q '# --- fonts ---' "$list"
+}
+
+@test "apt-packages-minimal.list is a strict subset of common basics" {
+    local list="$REPO_ROOT/share/apt-packages-minimal.list"
+    [ -r "$list" ]
+    # Spec calls out: git, curl, bash, ca-certificates.
+    grep -qxF 'git' "$list"
+    grep -qxF 'curl' "$list"
+    grep -qxF 'bash' "$list"
+    grep -qxF 'ca-certificates' "$list"
+}
+
+@test "apt-packages-server.list exists and is non-empty" {
+    local list="$REPO_ROOT/share/apt-packages-server.list"
+    [ -r "$list" ]
+    local count
+    count=$(grep -cv '^\s*\(#\|$\)' "$list")
+    [ "$count" -gt 0 ]
+}
+
+# --- script behaviour -------------------------------------------------------
+
+stage_list() {
+    local role="$1" ; shift
+    local dest="$BEGET_PACKAGE_DIR/apt-packages-${role}.list"
+    printf '%s\n' "$@" > "$dest"
+}
+
+@test "role=minimal installs ONLY the minimal list (not common)" {
+    stage_list common foo bar baz
+    stage_list minimal curl git
+
+    BEGET_ROLE=minimal run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CALL: curl git"* ]]
+    [[ "$output" != *"CALL: foo bar baz"* ]]
+}
+
+@test "role=workstation installs common + workstation" {
+    stage_list common alpha beta
+    stage_list workstation gamma
+
+    BEGET_ROLE=workstation run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CALL: alpha beta"* ]]
+    [[ "$output" == *"CALL: gamma"* ]]
+}
+
+@test "role=server installs common + server" {
+    stage_list common alpha
+    stage_list server delta epsilon
+
+    BEGET_ROLE=server run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CALL: alpha"* ]]
+    [[ "$output" == *"CALL: delta epsilon"* ]]
+}
+
+@test "comments and blank lines are skipped, whitespace trimmed" {
+    cat > "$BEGET_PACKAGE_DIR/apt-packages-minimal.list" <<'LIST'
+# leading comment
+
+git
+   curl
+bash   # trailing inline comment
+LIST
+
+    BEGET_ROLE=minimal run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CALL: git curl bash"* ]]
+}
+
+@test "empty list file emits a skip notice, no installer call" {
+    : > "$BEGET_PACKAGE_DIR/apt-packages-minimal.list"
+
+    BEGET_ROLE=minimal run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"nothing to install"* ]]
+    [[ "$output" != *"CALL:"* ]]
+}
+
+@test "missing list file warns and does not fail" {
+    # No file staged at all.
+    BEGET_ROLE=minimal run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skip missing list"* ]]
+}
+
+@test "unknown role falls back to common with a notice" {
+    stage_list common only-common-pkg
+
+    BEGET_ROLE=mystery run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unknown role mystery"* ]]
+    [[ "$output" == *"CALL: only-common-pkg"* ]]
+}
+
+@test "script is idempotent: two runs produce the same set of installer calls" {
+    stage_list common one two
+    stage_list workstation three
+
+    BEGET_ROLE=workstation run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    first="$output"
+
+    BEGET_ROLE=workstation run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$first" ]
+}


### PR DESCRIPTION
## Summary

Canonical newline-delimited APT package lists, role-scoped, plus the
run_onchange hook that installs them via lib/platform.sh::pkg_install.

## Changes

- share/apt-packages-common.list — 28 base CLI / dev / networking packages
- share/apt-packages-workstation.list — GUI/desktop (browsers, editors, messaging, media, fonts)
- share/apt-packages-server.list — server observability + network daemons
- share/apt-packages-minimal.list — bash/curl/git/ca-certificates only
- run_onchange_before_20-packages-common.sh — role-aware installer with chezmoi include hashes in comments for re-trigger
- tests/unit/apt-packages.bats — 12 tests: content, role scoping, comment/blank-line parsing, idempotency, missing-file tolerance, unknown-role fallback

## Test Results

- `make lint` green
- `make test-unit` 108/108 passing (12 new, 96 pre-existing)

## Linked Issues

Closes #18