### PR TITLE
feat(repos): register 11 third-party APT repos (+RHEL counterpart)

### DIFF
--- a/run_onchange_before_10-apt-repos.sh
+++ b/run_onchange_before_10-apt-repos.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# run_onchange_before_10-apt-repos.sh — register third-party APT repositories.
+#
+# Runs before the package-install hook (prefix 20) so that repo definitions
+# exist by the time `apt-get install` is invoked. Covers 10+ user-scoped repos
+# that ship proprietary / upstream packages not in the Ubuntu archive.
+#
+# Per repo, we:
+#   1. Download the GPG keyring (armored) to a temp file.
+#   2. Dearmor it and place the binary keyring under /etc/apt/keyrings/<name>.gpg.
+#   3. Emit a single-line sources.list.d file signed with that keyring.
+# After all repos are registered we run `apt update` ONCE to pick up indices.
+#
+# Fail-clean semantics: if ANY keyring fetch returns 404 (or any non-2xx), we
+# abort BEFORE writing the sources.list.d file for that repo. Partial state is
+# not persisted — the .list file is the trigger for apt to trust the repo, so
+# skipping it leaves the system in its prior working state for that repo.
+#
+# Idempotency: `install -m 0644 -T` overwrites existing keyrings and list
+# files byte-for-byte. `apt update` is harmless to re-run.
+#
+# Test seams (env-var overrides, default shown):
+#   BEGET_APT_KEYRINGS_DIR   — /etc/apt/keyrings
+#   BEGET_APT_SOURCES_DIR    — /etc/apt/sources.list.d
+#   BEGET_APT_DIST           — auto-detected from /etc/os-release (e.g. noble)
+#   BEGET_CURL               — curl
+#   BEGET_APT_UPDATE         — "sudo apt-get update"
+#   BEGET_SUDO               — sudo (tests swap in a recording stub)
+#   BEGET_SKIP_APT_UPDATE    — set to "1" to skip the final apt update
+#
+# The `main` function is only invoked when the script is executed directly;
+# when sourced (bats tests) it exposes helpers without side effects.
+
+set -euo pipefail
+
+BEGET_APT_KEYRINGS_DIR="${BEGET_APT_KEYRINGS_DIR:-/etc/apt/keyrings}"
+BEGET_APT_SOURCES_DIR="${BEGET_APT_SOURCES_DIR:-/etc/apt/sources.list.d}"
+BEGET_CURL="${BEGET_CURL:-curl}"
+BEGET_SUDO="${BEGET_SUDO:-sudo}"
+BEGET_APT_UPDATE="${BEGET_APT_UPDATE:-${BEGET_SUDO} apt-get update}"
+
+# Detect the Ubuntu release codename (noble, jammy, ...) unless overridden.
+detect_dist() {
+    if [[ -n "${BEGET_APT_DIST:-}" ]]; then
+        printf '%s' "$BEGET_APT_DIST"
+        return 0
+    fi
+    local os_release="${OS_RELEASE_FILE:-/etc/os-release}"
+    if [[ -r "$os_release" ]]; then
+        local codename
+        # shellcheck disable=SC1090
+        codename=$(. "$os_release" && printf '%s' "${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}")
+        if [[ -n "$codename" ]]; then
+            printf '%s' "$codename"
+            return 0
+        fi
+    fi
+    # Safe fallback so the helper never emits an empty dist in a sources line.
+    printf 'stable'
+}
+
+# Download the keyring at $1, dearmor it, install atomically to $2.
+# Returns 0 on success; non-zero on fetch failure (caller must abort the repo).
+install_keyring() {
+    local keyring_url="$1"
+    local dest_path="$2"
+    local tmp
+    tmp="$(mktemp)"
+    # Using -f makes curl exit non-zero on 4xx/5xx; -sS silences progress but
+    # keeps error messages; -L follows redirects.
+    if ! "$BEGET_CURL" -fsSL "$keyring_url" -o "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+    # gpg --dearmor is idempotent; destination is written atomically via
+    # `install -m 0644 -T`. Both steps run under sudo so production paths
+    # under /etc/apt/keyrings/ are writable.
+    local tmp_dearmored
+    tmp_dearmored="$(mktemp)"
+    gpg --dearmor < "$tmp" > "$tmp_dearmored"
+    "$BEGET_SUDO" install -m 0644 -T "$tmp_dearmored" "$dest_path"
+    rm -f "$tmp" "$tmp_dearmored"
+    return 0
+}
+
+# Emit a sources.list.d entry signed-by the named keyring. Writes
+# atomically; overwrites any prior content.
+write_sources_file() {
+    local name="$1"
+    local sources_line="$2"
+    local keyring_path="$3"
+    local dist
+    dist=$(detect_dist)
+    local dest="${BEGET_APT_SOURCES_DIR}/${name}.list"
+    local tmp
+    tmp="$(mktemp)"
+    # %s is the fully rendered sources line; callers template the dist name in.
+    local rendered="${sources_line//\{\{DIST\}\}/$dist}"
+    printf 'deb [signed-by=%s] %s\n' "$keyring_path" "$rendered" > "$tmp"
+    "$BEGET_SUDO" install -m 0644 -T "$tmp" "$dest"
+    rm -f "$tmp"
+}
+
+# Register one repo: name, sources_line template, keyring URL.
+# Sources line is the text AFTER "deb [signed-by=...] ". Substrings of
+# {{DIST}} are replaced with the detected codename.
+# On fetch failure, emits a warning and returns non-zero WITHOUT writing the
+# sources file — callers should choose whether to abort the whole run.
+register_repo() {
+    local name="$1"
+    local sources_line="$2"
+    local keyring_url="$3"
+    local keyring_path="${BEGET_APT_KEYRINGS_DIR}/${name}.gpg"
+
+    if ! install_keyring "$keyring_url" "$keyring_path"; then
+        printf 'run_onchange_before_10-apt-repos: failed to fetch keyring for %s (%s), skipping\n' \
+            "$name" "$keyring_url" >&2
+        return 1
+    fi
+    write_sources_file "$name" "$sources_line" "$keyring_path"
+    printf 'run_onchange_before_10-apt-repos: registered %s\n' "$name" >&2
+}
+
+# Ensure the keyring directory exists under sudo (production path is
+# owned by root).
+ensure_dirs() {
+    "$BEGET_SUDO" install -d -m 0755 "$BEGET_APT_KEYRINGS_DIR" "$BEGET_APT_SOURCES_DIR"
+}
+
+main() {
+    ensure_dirs
+
+    # Repo table: NAME|SOURCES_LINE|KEYRING_URL
+    # SOURCES_LINE uses {{DIST}} for the Ubuntu codename. One entry per line.
+    local -a repos=(
+        "mozilla|https://packages.mozilla.org/apt mozilla main|https://packages.mozilla.org/apt/repo-signing-key.gpg"
+        "google-chrome|https://dl.google.com/linux/chrome/deb/ stable main|https://dl.google.com/linux/linux_signing_key.pub"
+        "vivaldi|https://repo.vivaldi.com/stable/deb/ stable main|https://repo.vivaldi.com/stable/linux_signing_key.pub"
+        "slack|https://packagecloud.io/slacktechnologies/slack/debian/ jessie main|https://packagecloud.io/slacktechnologies/slack/gpgkey"
+        "spotify|http://repository.spotify.com stable non-free|https://download.spotify.com/debian/pubkey_6224F9941A8AA6D1.gpg"
+        "wezterm|https://apt.fury.io/wez/ * *|https://apt.fury.io/wez/gpg.key"
+        "hashicorp|https://apt.releases.hashicorp.com {{DIST}} main|https://apt.releases.hashicorp.com/gpg"
+        "vscode|https://packages.microsoft.com/repos/code stable main|https://packages.microsoft.com/keys/microsoft.asc"
+        "synaptics|https://synaptics.com/sites/default/files/Ubuntu {{DIST}} main|https://synaptics.com/sites/default/files/synaptics.gpg"
+        "nextcloud-devs|http://ppa.launchpad.net/nextcloud-devs/client/ubuntu {{DIST}} main|https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE0AB4EC4B5DE39A7C36249C2D67C3E6685166D1C"
+        "xtradeb-apps|http://ppa.launchpad.net/xtradeb/apps/ubuntu {{DIST}} main|https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x11031A9F63E8D6AFC4B58E2E62459C5CAFAB58E3"
+    )
+
+    local entry name sources keyring_url
+    local failures=0
+    for entry in "${repos[@]}"; do
+        IFS='|' read -r name sources keyring_url <<<"$entry"
+        if ! register_repo "$name" "$sources" "$keyring_url"; then
+            failures=$((failures + 1))
+        fi
+    done
+
+    if [[ "${BEGET_SKIP_APT_UPDATE:-}" != "1" ]]; then
+        # apt update is run even if some repos failed — the surviving repos
+        # must still refresh. Overall script still exits non-zero if any
+        # register_repo failed, so chezmoi surfaces the error.
+        $BEGET_APT_UPDATE
+    fi
+
+    if [[ $failures -gt 0 ]]; then
+        printf 'run_onchange_before_10-apt-repos: %d repo(s) failed\n' "$failures" >&2
+        return 1
+    fi
+}
+
+# Allow sourcing for tests without side effects: only run main when executed.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/run_onchange_before_10-dnf-repos.sh
+++ b/run_onchange_before_10-dnf-repos.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# run_onchange_before_10-dnf-repos.sh — register third-party DNF repositories
+# on Rocky/RHEL/Fedora. RHEL counterpart to run_onchange_before_10-apt-repos.sh.
+#
+# For each repo we:
+#   1. Download a .repo file (or write one from a base URL) under
+#      /etc/yum.repos.d/<name>.repo via `install -m 0644 -T`.
+#   2. Import the RPM-GPG key via `rpm --import`, so signature checks pass.
+# Finally we run `dnf makecache` so subsequent installs resolve against the
+# new repos.
+#
+# This script is a shim in the current wave: the Dev Spec lists RHEL as a
+# supported target but the third-party repo coverage is intentionally a
+# superset of what is commonly available on EPEL/RPM-Fusion/HashiCorp/etc.
+# Additional per-repo tables can be appended as needs arise.
+#
+# Idempotency: `install -T` overwrites existing files; `rpm --import` is a
+# no-op on already-trusted keys; `dnf makecache` is idempotent.
+#
+# Test seams (env-var overrides):
+#   BEGET_YUM_REPOS_DIR — /etc/yum.repos.d
+#   BEGET_CURL          — curl
+#   BEGET_SUDO          — sudo
+#   BEGET_RPM           — rpm
+#   BEGET_DNF           — dnf
+#   BEGET_SKIP_MAKECACHE — "1" to skip `dnf makecache`
+
+set -euo pipefail
+
+BEGET_YUM_REPOS_DIR="${BEGET_YUM_REPOS_DIR:-/etc/yum.repos.d}"
+BEGET_CURL="${BEGET_CURL:-curl}"
+BEGET_SUDO="${BEGET_SUDO:-sudo}"
+BEGET_RPM="${BEGET_RPM:-rpm}"
+BEGET_DNF="${BEGET_DNF:-dnf}"
+
+# Download a .repo file and install it atomically under $BEGET_YUM_REPOS_DIR.
+install_repo_file() {
+    local name="$1"
+    local repo_url="$2"
+    local tmp
+    tmp="$(mktemp)"
+    if ! "$BEGET_CURL" -fsSL "$repo_url" -o "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+    "$BEGET_SUDO" install -m 0644 -T "$tmp" "${BEGET_YUM_REPOS_DIR}/${name}.repo"
+    rm -f "$tmp"
+}
+
+# Trust the RPM signing key for a repo. Takes a URL or local path.
+import_rpm_key() {
+    local key_url="$1"
+    "$BEGET_SUDO" "$BEGET_RPM" --import "$key_url"
+}
+
+register_repo() {
+    local name="$1"
+    local repo_url="$2"
+    local key_url="$3"
+    if ! install_repo_file "$name" "$repo_url"; then
+        printf 'run_onchange_before_10-dnf-repos: failed to fetch %s (%s), skipping\n' \
+            "$name" "$repo_url" >&2
+        return 1
+    fi
+    import_rpm_key "$key_url"
+    printf 'run_onchange_before_10-dnf-repos: registered %s\n' "$name" >&2
+}
+
+ensure_dirs() {
+    "$BEGET_SUDO" install -d -m 0755 "$BEGET_YUM_REPOS_DIR"
+}
+
+main() {
+    ensure_dirs
+
+    # NAME|REPO_FILE_URL|RPM_GPG_KEY_URL
+    local -a repos=(
+        "hashicorp|https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo|https://rpm.releases.hashicorp.com/gpg"
+        "vscode|https://packages.microsoft.com/yumrepos/vscode/config.repo|https://packages.microsoft.com/keys/microsoft.asc"
+        "google-chrome|http://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome.repo|https://dl.google.com/linux/linux_signing_key.pub"
+    )
+
+    local entry name repo_url key_url
+    local failures=0
+    for entry in "${repos[@]}"; do
+        IFS='|' read -r name repo_url key_url <<<"$entry"
+        if ! register_repo "$name" "$repo_url" "$key_url"; then
+            failures=$((failures + 1))
+        fi
+    done
+
+    if [[ "${BEGET_SKIP_MAKECACHE:-}" != "1" ]]; then
+        "$BEGET_SUDO" "$BEGET_DNF" makecache
+    fi
+
+    if [[ $failures -gt 0 ]]; then
+        printf 'run_onchange_before_10-dnf-repos: %d repo(s) failed\n' "$failures" >&2
+        return 1
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/unit/apt-repos.bats
+++ b/tests/unit/apt-repos.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+# tests/unit/apt-repos.bats — unit tests for
+# run_onchange_before_10-apt-repos.sh (and companion dnf variant).
+#
+# We exercise the script via its documented env-var seams: stub curl,
+# sudo, and apt-get so we can assert on what would have been written to
+# /etc/apt/{keyrings,sources.list.d}/ and that apt-update was invoked
+# exactly once.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/run_onchange_before_10-apt-repos.sh"
+    DNF_SCRIPT="$REPO_ROOT/run_onchange_before_10-dnf-repos.sh"
+
+    export BEGET_APT_KEYRINGS_DIR="$BATS_TEST_TMPDIR/keyrings"
+    export BEGET_APT_SOURCES_DIR="$BATS_TEST_TMPDIR/sources.list.d"
+    export BEGET_APT_DIST="noble"
+    export BEGET_SKIP_APT_UPDATE=1
+
+    mkdir -p "$BEGET_APT_KEYRINGS_DIR" "$BEGET_APT_SOURCES_DIR"
+
+    # Stub sudo to a passthrough (`env $@`) so that `install`/`apt-get`/`rpm`
+    # commands execute as the test user against the BATS-owned temp dirs.
+    # We can't set BEGET_SUDO="" because the script uses ${BEGET_SUDO:-sudo}
+    # which substitutes on null values; instead we pass an explicit command.
+    export BEGET_SUDO="env"
+
+    # Stub curl to produce a deterministic keyring body. Successful fetch
+    # unless KEYRING_FAIL=1 is set, in which case we exit 22 (like curl -f
+    # does on HTTP 4xx).
+    cat > "$BATS_TEST_TMPDIR/fake-curl" <<'EOF'
+#!/usr/bin/env bash
+# Accept curl flags; final non-flag arg pairs: URL + (optional) -o FILE.
+# We only care about the URL and the -o destination.
+url=""
+out=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o) out="$2" ; shift 2 ;;
+        -*)         shift ;;
+        http*)      url="$1" ; shift ;;
+        *)          shift ;;
+    esac
+done
+if [[ "${KEYRING_FAIL:-0}" == "1" && "$url" == *"spotify"* ]]; then
+    exit 22
+fi
+# Produce something gpg --dearmor will accept: a minimal ASCII-armored block.
+printf -- '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFjQAAAB\n-----END PGP PUBLIC KEY BLOCK-----\n' \
+    > "${out:-/dev/stdout}"
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/fake-curl"
+    export BEGET_CURL="$BATS_TEST_TMPDIR/fake-curl"
+
+    # Stub gpg --dearmor so we don't depend on a working gpg in CI.
+    export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/gpg" <<'EOF'
+#!/usr/bin/env bash
+# Accept stdin, emit a fake binary keyring on stdout.
+cat > /dev/null
+printf 'FAKEGPG' > /dev/stdout
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/gpg"
+}
+
+@test "script declares 11 repos covering all spec-named sources" {
+    # Each repo row is a single line of form NAME|SOURCES|KEYRING in the
+    # repos= array. Assert presence of the spec-listed names.
+    for name in mozilla google-chrome vivaldi slack spotify wezterm \
+                hashicorp vscode synaptics nextcloud-devs xtradeb-apps; do
+        grep -q "^\\s*\"${name}|" "$SCRIPT" \
+            || { echo "missing repo row: $name" >&2 ; return 1 ; }
+    done
+}
+
+@test "successful run writes one keyring and one sources file per repo" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    local keyrings_count sources_count
+    keyrings_count=$(find "$BEGET_APT_KEYRINGS_DIR" -name '*.gpg' | wc -l)
+    sources_count=$(find "$BEGET_APT_SOURCES_DIR" -name '*.list' | wc -l)
+    [ "$keyrings_count" -eq 11 ]
+    [ "$sources_count" -eq 11 ]
+}
+
+@test "sources files reference signed-by=<keyring path>" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    local list="$BEGET_APT_SOURCES_DIR/hashicorp.list"
+    [ -r "$list" ]
+    grep -q "signed-by=${BEGET_APT_KEYRINGS_DIR}/hashicorp.gpg" "$list"
+    # {{DIST}} token is substituted with BEGET_APT_DIST.
+    grep -q 'noble' "$list"
+}
+
+@test "keyrings land under BEGET_APT_KEYRINGS_DIR with 0644 perms" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    local kr="$BEGET_APT_KEYRINGS_DIR/mozilla.gpg"
+    [ -r "$kr" ]
+    # Under `install -m 0644` the resulting file is mode 644.
+    local perm
+    perm=$(stat -c '%a' "$kr")
+    [ "$perm" = "644" ]
+}
+
+@test "404 on one keyring aborts THAT repo only; no partial sources file" {
+    KEYRING_FAIL=1 run bash "$SCRIPT"
+    # Overall non-zero exit because at least one repo failed.
+    [ "$status" -ne 0 ]
+    # spotify should have been skipped; no spotify.list present.
+    [ ! -r "$BEGET_APT_SOURCES_DIR/spotify.list" ]
+    # Other repos still registered.
+    [ -r "$BEGET_APT_SOURCES_DIR/mozilla.list" ]
+    [ -r "$BEGET_APT_SOURCES_DIR/hashicorp.list" ]
+    # User-facing diagnostic mentions the failed repo.
+    [[ "$output" == *"failed to fetch keyring for spotify"* ]]
+}
+
+@test "script is idempotent: running twice yields the same filesystem" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    first=$(find "$BEGET_APT_KEYRINGS_DIR" "$BEGET_APT_SOURCES_DIR" \
+        -type f -printf '%p %s\n' | sort)
+
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    second=$(find "$BEGET_APT_KEYRINGS_DIR" "$BEGET_APT_SOURCES_DIR" \
+        -type f -printf '%p %s\n' | sort)
+
+    [ "$first" = "$second" ]
+}
+
+@test "apt update is invoked exactly once unless BEGET_SKIP_APT_UPDATE=1" {
+    unset BEGET_SKIP_APT_UPDATE
+    # Force the default (BEGET_APT_UPDATE unset so script rebuilds command from
+    # BEGET_SUDO). Guards against a leaked env var from an enclosing shell.
+    unset BEGET_APT_UPDATE
+    # Stub apt-get to log calls.
+    cat > "$BATS_TEST_TMPDIR/bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+echo "APT:$*" >> "${APT_LOG}"
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/apt-get"
+    export APT_LOG="$BATS_TEST_TMPDIR/apt.log"
+    : > "$APT_LOG"
+
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # Expect exactly one apt-get update call. `|| echo 0` keeps grep's
+    # non-zero exit on zero matches from tripping `set -e` via $(..).
+    # grep -c prints 0 and exits 1 on no match; use || true to tolerate.
+    local n
+    n=$(grep -c 'APT:update' "$APT_LOG" 2>/dev/null || true)
+    [ "${n:-0}" = "1" ]
+}
+
+@test "dnf variant: declares hashicorp/vscode/google-chrome rows" {
+    grep -q '^\s*"hashicorp|' "$DNF_SCRIPT"
+    grep -q '^\s*"vscode|' "$DNF_SCRIPT"
+    grep -q '^\s*"google-chrome|' "$DNF_SCRIPT"
+}
+
+@test "dnf variant: happy-path writes .repo files and skips makecache" {
+    export BEGET_YUM_REPOS_DIR="$BATS_TEST_TMPDIR/yum.repos.d"
+    export BEGET_SKIP_MAKECACHE=1
+    export BEGET_SUDO="env"
+    mkdir -p "$BEGET_YUM_REPOS_DIR"
+
+    # Stub rpm to a no-op.
+    cat > "$BATS_TEST_TMPDIR/bin/rpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/rpm"
+
+    run bash "$DNF_SCRIPT"
+    [ "$status" -eq 0 ]
+    [ -r "$BEGET_YUM_REPOS_DIR/hashicorp.repo" ]
+    [ -r "$BEGET_YUM_REPOS_DIR/vscode.repo" ]
+    [ -r "$BEGET_YUM_REPOS_DIR/google-chrome.repo" ]
+}


### PR DESCRIPTION
## Summary

run_onchange_before_10-apt-repos.sh installs GPG keyrings under
/etc/apt/keyrings/ and writes per-repo signed-by sources files for 11
third-party upstreams, then runs `apt update` once. Companion
run_onchange_before_10-dnf-repos.sh does the equivalent on RHEL via
.repo files + rpm --import.

## Changes

- run_onchange_before_10-apt-repos.sh — covers mozilla, google-chrome, vivaldi, slack, spotify, wezterm, hashicorp, vscode, synaptics, nextcloud-devs, xtradeb-apps. Fail-clean on 404 (keyring fetch must succeed before the sources file is written).
- run_onchange_before_10-dnf-repos.sh — hashicorp, vscode, google-chrome .repo files with rpm --import keys.
- tests/unit/apt-repos.bats — 9 tests with stubbed curl/gpg/sudo/apt-get via documented env-var seams; asserts idempotency, single apt-update, and fail-clean semantics.

## Test Results

- `make lint` green
- `make test-unit` 105/105 passing (9 new, 96 pre-existing)

## Linked Issues

Closes #19