### PR TITLE
feat(sysctl): install vm.max_map_count + AppArmor userns drop-ins

### DIFF
--- a/run_onchange_before_30-sysctl.sh
+++ b/run_onchange_before_30-sysctl.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# run_onchange_before_30-sysctl.sh — install and activate system-level sysctl
+# tweaks from share/sysctl.d/.
+#
+# For each .conf file in our shipped directory, copy it to /etc/sysctl.d/
+# (preserving the filename), then run `sysctl --system` once to reload all
+# drop-ins.
+#
+# Idempotency: install -T overwrites byte-for-byte; `sysctl --system` is safe
+# to re-invoke.
+#
+# The chezmoi include hashes below cause this script to re-run when the
+# sysctl.d/ files change:
+#   10-map-count.conf:         {{ include "share/sysctl.d/10-map-count.conf" | sha256sum }}
+#   60-carbonyl-userns.conf:   {{ include "share/sysctl.d/60-carbonyl-userns.conf" | sha256sum }}
+#
+# Test seams (env-var overrides, default shown):
+#   BEGET_SYSCTL_SRC_DIR  — $HOME/.local/share/beget/sysctl.d (prod path)
+#   BEGET_SYSCTL_DEST_DIR — /etc/sysctl.d
+#   BEGET_SUDO            — sudo
+#   BEGET_SYSCTL          — sysctl
+#   BEGET_SKIP_RELOAD     — "1" to skip `sysctl --system`
+
+set -euo pipefail
+
+BEGET_SYSCTL_SRC_DIR="${BEGET_SYSCTL_SRC_DIR:-${HOME}/.local/share/beget/sysctl.d}"
+BEGET_SYSCTL_DEST_DIR="${BEGET_SYSCTL_DEST_DIR:-/etc/sysctl.d}"
+BEGET_SUDO="${BEGET_SUDO:-sudo}"
+BEGET_SYSCTL="${BEGET_SYSCTL:-sysctl}"
+
+install_conf() {
+    local src="$1"
+    local name
+    name=$(basename "$src")
+    local dest="${BEGET_SYSCTL_DEST_DIR}/${name}"
+    "$BEGET_SUDO" install -m 0644 -T "$src" "$dest"
+    printf 'run_onchange_before_30-sysctl: installed %s\n' "$name" >&2
+}
+
+main() {
+    if [[ ! -d "$BEGET_SYSCTL_SRC_DIR" ]]; then
+        printf 'run_onchange_before_30-sysctl: source dir not found: %s\n' \
+            "$BEGET_SYSCTL_SRC_DIR" >&2
+        return 1
+    fi
+
+    # Ensure destination dir exists (it always does in production; test seam
+    # covers cases where BEGET_SYSCTL_DEST_DIR points to a tmpdir).
+    "$BEGET_SUDO" install -d -m 0755 "$BEGET_SYSCTL_DEST_DIR"
+
+    local installed=0
+    shopt -s nullglob
+    local f
+    for f in "$BEGET_SYSCTL_SRC_DIR"/*.conf; do
+        install_conf "$f"
+        installed=$((installed + 1))
+    done
+    shopt -u nullglob
+
+    if [[ $installed -eq 0 ]]; then
+        printf 'run_onchange_before_30-sysctl: no .conf files found in %s\n' \
+            "$BEGET_SYSCTL_SRC_DIR" >&2
+        return 0
+    fi
+
+    if [[ "${BEGET_SKIP_RELOAD:-}" != "1" ]]; then
+        "$BEGET_SUDO" "$BEGET_SYSCTL" --system
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/share/sysctl.d/10-map-count.conf
+++ b/share/sysctl.d/10-map-count.conf
@@ -1,0 +1,14 @@
+# /etc/sysctl.d/10-map-count.conf
+#
+# WHAT:  Raise the per-process upper bound on memory-mapped regions.
+# WHY:   Modern IDEs (VS Code, JetBrains), Chromium-based browsers, and
+#        Elasticsearch-style JVM apps routinely exceed the kernel default of
+#        65_530 mmap regions under heavy workloads, which surfaces as opaque
+#        "bad address" / "out of memory" errors even on hosts with free RAM.
+#        The value below (1 Mi) matches Elasticsearch's recommended setting
+#        and has been a long-standing workstation default.
+# WHO:   All roles (workstation, server, minimal). Cost is negligible (only
+#        affects virtual address-space accounting, not physical memory).
+#
+# Deployed by: run_onchange_before_30-sysctl.sh
+vm.max_map_count = 1048576

--- a/share/sysctl.d/60-carbonyl-userns.conf
+++ b/share/sysctl.d/60-carbonyl-userns.conf
@@ -1,0 +1,17 @@
+# /etc/sysctl.d/60-carbonyl-userns.conf
+#
+# WHAT:  Disable AppArmor's restriction on unprivileged user namespaces.
+# WHY:   Ubuntu 24.04 (noble) ships AppArmor with
+#        `kernel.apparmor_restrict_unprivileged_userns=1` by default, which
+#        breaks Chromium-family sandboxes including Google Chrome, Electron
+#        apps (VS Code, Slack, Discord), and Carbonyl (text-mode Chromium
+#        terminal browser). Upstream's fix is to install per-app AppArmor
+#        profiles; until those land uniformly, disabling the restriction
+#        system-wide is the documented workaround.
+# WHO:   Workstation role primarily; harmless on server/minimal.
+# CAVEAT: This relaxes a hardening default. A future wave should replace
+#         this with targeted AppArmor profiles once upstream coverage is
+#         adequate.
+#
+# Deployed by: run_onchange_before_30-sysctl.sh
+kernel.apparmor_restrict_unprivileged_userns = 0

--- a/tests/unit/sysctl.bats
+++ b/tests/unit/sysctl.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# tests/unit/sysctl.bats — unit tests for run_onchange_before_30-sysctl.sh
+# and the companion share/sysctl.d/*.conf files.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/run_onchange_before_30-sysctl.sh"
+
+    export BEGET_SYSCTL_SRC_DIR="$BATS_TEST_TMPDIR/src"
+    export BEGET_SYSCTL_DEST_DIR="$BATS_TEST_TMPDIR/dest"
+    mkdir -p "$BEGET_SYSCTL_SRC_DIR" "$BEGET_SYSCTL_DEST_DIR"
+
+    # Passthrough sudo (cannot use empty — script uses ${BEGET_SUDO:-sudo}).
+    export BEGET_SUDO="env"
+
+    # Stub sysctl to log invocations.
+    export SYSCTL_LOG="$BATS_TEST_TMPDIR/sysctl.log"
+    : > "$SYSCTL_LOG"
+    cat > "$BATS_TEST_TMPDIR/fake-sysctl" <<'EOF'
+#!/usr/bin/env bash
+echo "SYSCTL:$*" >> "${SYSCTL_LOG}"
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/fake-sysctl"
+    export BEGET_SYSCTL="$BATS_TEST_TMPDIR/fake-sysctl"
+}
+
+# --- shipped file content ---------------------------------------------------
+
+@test "share/sysctl.d/10-map-count.conf sets vm.max_map_count=1048576" {
+    local f="$REPO_ROOT/share/sysctl.d/10-map-count.conf"
+    [ -r "$f" ]
+    grep -E '^vm\.max_map_count\s*=\s*1048576' "$f"
+}
+
+@test "10-map-count.conf contains header comments explaining what/why" {
+    local f="$REPO_ROOT/share/sysctl.d/10-map-count.conf"
+    # WHAT and WHY markers are required by the Dev Spec AC.
+    grep -q '^# WHAT:' "$f"
+    grep -q '^# WHY:' "$f"
+}
+
+@test "share/sysctl.d/60-carbonyl-userns.conf disables userns restriction" {
+    local f="$REPO_ROOT/share/sysctl.d/60-carbonyl-userns.conf"
+    [ -r "$f" ]
+    grep -E '^kernel\.apparmor_restrict_unprivileged_userns\s*=\s*0' "$f"
+}
+
+@test "60-carbonyl-userns.conf contains header comments explaining what/why" {
+    local f="$REPO_ROOT/share/sysctl.d/60-carbonyl-userns.conf"
+    grep -q '^# WHAT:' "$f"
+    grep -q '^# WHY:' "$f"
+}
+
+# --- script behaviour -------------------------------------------------------
+
+stage_conf() {
+    local name="$1"; local body="$2"
+    printf '%s\n' "$body" > "$BEGET_SYSCTL_SRC_DIR/$name"
+}
+
+@test "happy path: copies all .conf files and reloads sysctl" {
+    stage_conf "10-a.conf" "net.ipv4.tcp_syncookies = 1"
+    stage_conf "20-b.conf" "vm.swappiness = 10"
+
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+
+    [ -r "$BEGET_SYSCTL_DEST_DIR/10-a.conf" ]
+    [ -r "$BEGET_SYSCTL_DEST_DIR/20-b.conf" ]
+    # Exactly one sysctl --system call was emitted.
+    local n
+    n=$(grep -c 'SYSCTL:--system' "$SYSCTL_LOG" 2>/dev/null || true)
+    [ "${n:-0}" = "1" ]
+}
+
+@test "installed files have 0644 perms" {
+    stage_conf "10-a.conf" "fs.inotify.max_user_watches = 524288"
+
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+
+    local perm
+    perm=$(stat -c '%a' "$BEGET_SYSCTL_DEST_DIR/10-a.conf")
+    [ "$perm" = "644" ]
+}
+
+@test "idempotent: running twice yields identical destination state" {
+    stage_conf "10-a.conf" "vm.swappiness = 10"
+
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    first=$(find "$BEGET_SYSCTL_DEST_DIR" -type f -printf '%p %s\n' | sort)
+
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    second=$(find "$BEGET_SYSCTL_DEST_DIR" -type f -printf '%p %s\n' | sort)
+
+    [ "$first" = "$second" ]
+}
+
+@test "BEGET_SKIP_RELOAD=1 skips the sysctl --system reload" {
+    stage_conf "10-a.conf" "vm.swappiness = 10"
+
+    BEGET_SKIP_RELOAD=1 run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$SYSCTL_LOG" ]
+}
+
+@test "missing source dir → non-zero exit with diagnostic" {
+    rm -rf "$BEGET_SYSCTL_SRC_DIR"
+    run bash "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"source dir not found"* ]]
+}
+
+@test "empty source dir succeeds with notice and no sysctl reload" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no .conf files found"* ]]
+    [ ! -s "$SYSCTL_LOG" ]
+}
+
+@test "real shipped files install under dest dir (smoke test)" {
+    # Wire the shipped source dir in place of the staged one.
+    BEGET_SYSCTL_SRC_DIR="$REPO_ROOT/share/sysctl.d" \
+        run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ -r "$BEGET_SYSCTL_DEST_DIR/10-map-count.conf" ]
+    [ -r "$BEGET_SYSCTL_DEST_DIR/60-carbonyl-userns.conf" ]
+}


### PR DESCRIPTION
## Summary

Ship two sysctl drop-ins under share/sysctl.d/ and the
run_onchange_before_30-sysctl.sh hook that installs them to
/etc/sysctl.d/ and runs `sysctl --system`.

## Changes

- share/sysctl.d/10-map-count.conf — `vm.max_map_count = 1048576` (IDEs, Chromium, JVM workloads).
- share/sysctl.d/60-carbonyl-userns.conf — `kernel.apparmor_restrict_unprivileged_userns = 0` (Ubuntu 24.04 Chromium sandbox workaround).
- Both files carry WHAT/WHY header comments per Dev Spec AC.
- run_onchange_before_30-sysctl.sh — installs all .conf files via `install -m 0644 -T`, then `sysctl --system` once (skip-reload seam for tests).
- tests/unit/sysctl.bats — 11 tests: content, perms, idempotency, missing/empty source dir, reload-skip, smoke test against the real shipped files.

## Test Results

- `make lint` green
- `make test-unit` 107/107 passing (11 new, 96 pre-existing)

## Linked Issues

Closes #20