### PR TITLE
feat(ci): GitHub Actions pipeline with 5 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: ci
+
+# Triggers: every pull_request to any branch + every push to main.
+# Keep jobs discrete; each job's output should be ≤10 minutes on the default
+# hosted runners (acceptance criterion for Story #25). Procedural logic lives
+# in scripts/ci/ — YAML stays declarative (project rule, see CLAUDE.md).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/ci/install-lint-deps.sh
+      - run: ./scripts/ci/run-lint.sh
+
+  template-render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/chezmoi
+          key: chezmoi-${{ runner.os }}
+      - run: ./scripts/ci/install-chezmoi.sh
+      - run: ./scripts/ci/run-template-render.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: template-render-junit
+          path: tests/results/*.xml
+          if-no-files-found: ignore
+
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: ./scripts/ci/install-unit-deps.sh
+      - run: ./scripts/ci/run-unit.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-junit
+          path: tests/results/*.xml
+          if-no-files-found: ignore
+
+  e2e-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: ./scripts/ci/run-e2e.sh ubuntu24
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-ubuntu-junit
+          path: tests/results/*.xml
+          if-no-files-found: ignore
+
+  e2e-rocky:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: ./scripts/ci/run-e2e.sh rocky9
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-rocky-junit
+          path: tests/results/*.xml
+          if-no-files-found: ignore

--- a/scripts/ci/install-chezmoi.sh
+++ b/scripts/ci/install-chezmoi.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# scripts/ci/install-chezmoi.sh — install chezmoi for the template-render job.
+#
+# Uses the upstream install.sh which is the canonical install path. We pin
+# to a known good version to make the CI deterministic. Binary lands in
+# /usr/local/bin and is ready for `chezmoi execute-template`.
+set -euo pipefail
+
+CHEZMOI_VERSION="${CHEZMOI_VERSION:-v2.55.0}"
+sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin -t "$CHEZMOI_VERSION"
+
+chezmoi --version

--- a/scripts/ci/install-lint-deps.sh
+++ b/scripts/ci/install-lint-deps.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# scripts/ci/install-lint-deps.sh — install shellcheck + shfmt for the lint job.
+#
+# Invoked by .github/workflows/ci.yml (lint job). Keep this idempotent —
+# the cache action may or may not have populated ~/.cache/shellcheck.
+set -euo pipefail
+
+sudo apt-get update -yq
+sudo apt-get install -yq shellcheck shfmt
+
+shellcheck --version
+shfmt --version

--- a/scripts/ci/install-unit-deps.sh
+++ b/scripts/ci/install-unit-deps.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# scripts/ci/install-unit-deps.sh — ensure bats is available for the unit
+# job. The repo vendors bats-core as a submodule at tests/bats; we just
+# need the submodule initialized (the checkout step may already have done
+# this, but double-check so a fresh cache still works).
+set -euo pipefail
+
+git submodule update --init --recursive tests/bats
+
+tests/bats/bin/bats --version

--- a/scripts/ci/run-e2e.sh
+++ b/scripts/ci/run-e2e.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scripts/ci/run-e2e.sh — run the E2E smoke suite for a given distro image.
+#
+# Usage: scripts/ci/run-e2e.sh <distro>
+# where <distro> matches a Dockerfile.<distro> under tests/e2e/.
+#
+# Delegates to `make test-e2e` when wired up (Story #29). Until then, the
+# fallback builds the Dockerfile for <distro>, runs each e2e-XX-*.sh inside
+# a fresh container, and captures a single-suite JUnit XML.
+set -euo pipefail
+
+distro="${1:?distro argument required (ubuntu24 | rocky9)}"
+
+mkdir -p tests/results
+
+# Preferred path once Story #29 lands.
+if make -n test-e2e >/dev/null 2>&1; then
+    exec make test-e2e DISTRO="$distro"
+fi
+
+dockerfile="tests/e2e/Dockerfile.${distro}"
+if [[ ! -f "$dockerfile" ]]; then
+    echo "e2e: no Dockerfile.$distro found (pending Story #28) — skipping" >&2
+    # Emit an empty-but-valid JUnit file so artifact upload has something.
+    cat >"tests/results/e2e-${distro}.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="e2e-${distro}" tests="0" failures="0" errors="0" skipped="0"/>
+EOF
+    exit 0
+fi
+
+image="beget-e2e:${distro}"
+docker build -f "$dockerfile" -t "$image" .
+
+shopt -s nullglob
+scripts=(tests/e2e/e2e-*.sh)
+if [[ ${#scripts[@]} -eq 0 ]]; then
+    echo "e2e: no e2e-XX-*.sh scripts yet (pending Story #28)" >&2
+    exit 0
+fi
+
+fail=0
+for s in "${scripts[@]}"; do
+    name="$(basename "$s" .sh)"
+    printf '\n=== %s on %s ===\n' "$name" "$distro"
+    # No --privileged: the e2e scripts under tests/e2e/ don't touch systemd or
+    # devices. If a future test needs a specific capability, add it narrowly
+    # (--cap-add=...) with justification rather than re-enabling --privileged.
+    if ! docker run --rm -v "$PWD:/src" -w /src "$image" bash "$s"; then
+        fail=1
+    fi
+done
+exit "$fail"

--- a/scripts/ci/run-lint.sh
+++ b/scripts/ci/run-lint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# scripts/ci/run-lint.sh — execute the `lint` job's checks.
+#
+# Runs `make lint` (shellcheck). On this CI pipeline `make lint` already
+# covers install.sh, lib/*.sh, and run_onchange_* scripts. Keep thin: any
+# additional linting belongs in the Makefile, not here.
+set -euo pipefail
+
+make lint

--- a/scripts/ci/run-template-render.sh
+++ b/scripts/ci/run-template-render.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# scripts/ci/run-template-render.sh — render every *.tmpl with chezmoi
+# execute-template, using deterministic fixture values for template variables.
+#
+# Delegates to tests/integration/chezmoi-render.sh, which is added by Story #27
+# and is responsible for setting up a fixture chezmoi source dir (including
+# rbw stubs and included asset files) before invoking chezmoi execute-template.
+#
+# Until #27 lands, emit an empty-but-valid JUnit file and exit 0 — the unit
+# and e2e jobs still run and provide signal. This mirrors the graceful-skip
+# pattern in run-e2e.sh so the CI pipeline can ship before all dependent
+# integration fixtures exist.
+set -euo pipefail
+
+mkdir -p tests/results
+
+if [[ -x tests/integration/chezmoi-render.sh ]]; then
+    exec tests/integration/chezmoi-render.sh
+fi
+
+echo "template-render: tests/integration/chezmoi-render.sh not present (pending Story #27) — skipping" >&2
+cat >tests/results/template-render.xml <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="template-render" tests="0" failures="0" errors="0" skipped="0"/>
+EOF
+exit 0

--- a/scripts/ci/run-unit.sh
+++ b/scripts/ci/run-unit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# scripts/ci/run-unit.sh — run bats unit tests, emitting JUnit XML when
+# supported by the vendored bats version.
+#
+# install-unit-deps.sh already initialized the tests/bats submodule. The
+# `make test-unit` target only wraps the same `bats tests/unit` call plus a
+# `bootstrap-test-deps` step; we intentionally invoke bats directly so we
+# can pass `--formatter junit` when available for artifact upload.
+set -euo pipefail
+
+mkdir -p tests/results
+
+if tests/bats/bin/bats --help 2>&1 | grep -q -- '--formatter'; then
+    exec tests/bats/bin/bats --formatter junit --output tests/results tests/unit
+fi
+
+exec tests/bats/bin/bats tests/unit


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` with 5 jobs (lint, template-render, unit, e2e-ubuntu, e2e-rocky), plus 7 helper scripts under `scripts/ci/` to keep the YAML thin per the CLAUDE.md ≤5-line rule.

## Changes

- `.github/workflows/ci.yml` — triggers on PR + push-to-main; concurrency cancels stale runs per ref
- `scripts/ci/install-{lint,unit,chezmoi}-deps.sh` — per-job dependency setup
- `scripts/ci/run-{lint,template-render,unit,e2e}.sh` — job bodies
- Graceful fallbacks: `run-template-render.sh` skips with empty JUnit if `tests/integration/chezmoi-render.sh` is not present yet (arriving in #27); `run-e2e.sh` skips if `tests/e2e/Dockerfile.<distro>` is missing (arriving in #28)
- JUnit XML uploaded with `if: always()` on template-render, unit, e2e jobs

## Linked Issues

Closes #25

## Test Plan

- [x] `make lint` clean on the branch
- [x] `shellcheck scripts/ci/*.sh` clean
- [x] `shfmt -i 4 -ci -d scripts/ci/*.sh` clean
- [x] Local dry-run of `run-template-render.sh` graceful skip (exit 0, valid JUnit)
- [x] Local dry-run of `run-e2e.sh ubuntu24` graceful skip (no Dockerfile present → exit 0)
- [x] trivy HIGH/CRITICAL: 0 findings
- [ ] CI green on this PR (the pipeline it is adding validates itself)

## Code Review Fixes

Three findings from `feature-dev:code-reviewer` addressed in-branch before commit:
- Dropped `--privileged` from `docker run` in e2e fallback (no e2e uses systemd)
- Simplified `run-unit.sh` to invoke bats directly (the `make test-unit` wrapper added nothing beyond `install-unit-deps.sh`)
- Removed bogus shellcheck cache (apt-installed binary does not land under `~/.cache/shellcheck`)