### PR TITLE
feat(tests): bats unit suite — mock_rbw helper + os-detection/secret tests

### DIFF
--- a/tests/helpers/mocks.sh
+++ b/tests/helpers/mocks.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
-# tests/helpers/mocks.sh — test helpers for platform.sh
+# tests/helpers/mocks.sh — shared test helpers.
 #
-# Provides make_os_release() to write a mock /etc/os-release file into a
-# temp dir and point OS_RELEASE_FILE at it.
+# Exposes two families of helpers:
+#   * make_os_release / reset_os_env — seed a mock /etc/os-release and
+#     point platform.sh at it via OS_RELEASE_FILE.
+#   * mock_rbw — install a fake `rbw` binary under $BATS_TEST_TMPDIR and
+#     point BEGET_RBW_CMD at it. Behaviors: ok | missing | locked |
+#     unreachable, matching the categories in dot_bashrc.d/executable_50-wrappers.sh.
+#
+# Keep this library hermetic — it must never mutate the host. Everything
+# lands under $BATS_TEST_TMPDIR which bats cleans up per test.
 
 # make_os_release <id> <version_id> [pretty_name]
 # Writes a minimal os-release file to "$BATS_TEST_TMPDIR/os-release" and
@@ -28,4 +35,60 @@ EOF
 # reset_os_env — clear OS-related env so each test starts fresh.
 reset_os_env() {
     unset OS_ID OS_MAJOR_VERSION OS_RELEASE_FILE
+}
+
+# mock_rbw <behavior> [value]
+# Install a deterministic `rbw` shim under $BATS_TEST_TMPDIR/shim-rbw and
+# point BEGET_RBW_CMD at it. Behaviors:
+#   ok         — `get` prints <value> (default "secret-value") and exits 0.
+#   missing    — `get` exits 1 with "no item" on stderr.
+#   locked     — `get` exits 2 with "rbw is locked".
+#   unreachable— `get` exits 3 with "network error".
+# The shim logs calls to $BATS_TEST_TMPDIR/rbw-calls.log so tests can
+# assert on how rbw was invoked.
+mock_rbw() {
+    local behavior="${1:-ok}"
+    local value="${2:-secret-value}"
+
+    local tmpdir="${BATS_TEST_TMPDIR:-${TMPDIR:-/tmp}}"
+    local shim_dir="${tmpdir}/shim-rbw"
+    mkdir -p "$shim_dir"
+
+    local shim_path="${shim_dir}/rbw"
+    local log_path="${tmpdir}/rbw-calls.log"
+    : >"$log_path"
+
+    export BEGET_RBW_CMD="$shim_path"
+    export MOCK_RBW_LOG="$log_path"
+
+    cat >"$shim_path" <<EOF
+#!/usr/bin/env bash
+# Mock rbw installed by tests/helpers/mocks.sh::mock_rbw.
+printf '%s\n' "\$*" >>"$log_path"
+sub="\${1:-}"
+item="\${2:-}"
+case "\$sub" in
+  get)
+    case "$behavior" in
+      ok)          printf '%s' '$value'; exit 0 ;;
+      missing)     echo "rbw get: no item named \$item" >&2; exit 1 ;;
+      locked)      echo "rbw is locked" >&2; exit 2 ;;
+      unreachable) echo "rbw: network error" >&2; exit 3 ;;
+    esac
+    ;;
+  add)
+    value_in="\$(cat)"
+    printf 'add %s value=%s\n' "\$item" "\$value_in" >>"$log_path"
+    case "$behavior" in
+      ok)      exit 0 ;;
+      missing) echo "rbw add: synthetic failure" >&2; exit 1 ;;
+      *)       exit 0 ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+    chmod +x "$shim_path"
 }

--- a/tests/unit/os-detection.bats
+++ b/tests/unit/os-detection.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/unit/os-detection.bats — OS-release edge-case coverage for
+# lib/platform.sh::source_os_release and die_if_unsupported_os.
+#
+# Focus: cases tests/unit/platform.bats doesn't cover — quoting variants,
+# unusual version strings, codename-only releases, and boundary conditions
+# on die_if_unsupported_os.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+    reset_os_env
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/lib/platform.sh"
+}
+
+teardown() {
+    reset_os_env
+}
+
+# ---- source_os_release quoting and format variants -------------------------
+
+@test "source_os_release: unquoted ID, quoted VERSION_ID" {
+    cat >"$BATS_TEST_TMPDIR/os-release" <<'EOF'
+NAME="Ubuntu"
+ID=ubuntu
+VERSION_ID="24.04"
+EOF
+    export OS_RELEASE_FILE="$BATS_TEST_TMPDIR/os-release"
+    source_os_release
+    [ "$OS_ID" = "ubuntu" ]
+    [ "$OS_MAJOR_VERSION" = "24" ]
+}
+
+@test "source_os_release: quoted ID, unquoted VERSION_ID" {
+    cat >"$BATS_TEST_TMPDIR/os-release" <<'EOF'
+NAME="Rocky Linux"
+ID="rocky"
+VERSION_ID=9
+EOF
+    export OS_RELEASE_FILE="$BATS_TEST_TMPDIR/os-release"
+    source_os_release
+    [ "$OS_ID" = "rocky" ]
+    [ "$OS_MAJOR_VERSION" = "9" ]
+}
+
+@test "source_os_release: VERSION_ID with three segments extracts major" {
+    cat >"$BATS_TEST_TMPDIR/os-release" <<'EOF'
+ID=almalinux
+VERSION_ID="9.3.0"
+EOF
+    export OS_RELEASE_FILE="$BATS_TEST_TMPDIR/os-release"
+    source_os_release
+    [ "$OS_ID" = "almalinux" ]
+    [ "$OS_MAJOR_VERSION" = "9" ]
+}
+
+@test "source_os_release: missing VERSION_ID leaves OS_MAJOR_VERSION empty" {
+    cat >"$BATS_TEST_TMPDIR/os-release" <<'EOF'
+ID=rocky
+EOF
+    export OS_RELEASE_FILE="$BATS_TEST_TMPDIR/os-release"
+    source_os_release
+    [ "$OS_ID" = "rocky" ]
+    [ -z "$OS_MAJOR_VERSION" ]
+}
+
+@test "source_os_release: missing ID aborts" {
+    cat >"$BATS_TEST_TMPDIR/os-release" <<'EOF'
+NAME="No ID Field"
+VERSION_ID="9"
+EOF
+    export OS_RELEASE_FILE="$BATS_TEST_TMPDIR/os-release"
+    run source_os_release
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"missing ID"* ]]
+}
+
+@test "source_os_release: blank file aborts" {
+    : >"$BATS_TEST_TMPDIR/os-release"
+    export OS_RELEASE_FILE="$BATS_TEST_TMPDIR/os-release"
+    run source_os_release
+    [ "$status" -ne 0 ]
+}
+
+@test "source_os_release: does not leak sibling os-release fields into env" {
+    # Sanity check that the subshell trick in platform.sh keeps noisy
+    # fields (NAME, PRETTY_NAME, BUILD_ID) out of the caller's env.
+    make_os_release "ubuntu" "24.04" "Ubuntu 24.04 LTS"
+    # Pre-unset a field set by make_os_release — we want to prove
+    # source_os_release doesn't re-introduce it.
+    unset NAME PRETTY_NAME
+    source_os_release
+    [ -z "${NAME:-}" ]
+    [ -z "${PRETTY_NAME:-}" ]
+}
+
+# ---- die_if_unsupported_os boundary cases ----------------------------------
+
+@test "die_if_unsupported_os: Rocky 10 (future major) aborts" {
+    make_os_release "rocky" "10.0"
+    run die_if_unsupported_os
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS"* ]]
+}
+
+@test "die_if_unsupported_os: Ubuntu 26.04 (future major) aborts" {
+    make_os_release "ubuntu" "26.04"
+    run die_if_unsupported_os
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS"* ]]
+}
+
+@test "die_if_unsupported_os: Fedora rejects (not in supported set)" {
+    make_os_release "fedora" "40"
+    run die_if_unsupported_os
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS"* ]]
+    [[ "$output" == *"fedora"* ]]
+}
+
+@test "die_if_unsupported_os: Centos 9 (close to Rocky but not supported) aborts" {
+    make_os_release "centos" "9"
+    run die_if_unsupported_os
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS"* ]]
+}
+
+@test "die_if_unsupported_os: AlmaLinux 9 aborts (only Rocky 9 is whitelisted)" {
+    make_os_release "almalinux" "9.3"
+    run die_if_unsupported_os
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS"* ]]
+}

--- a/tests/unit/secret.bats
+++ b/tests/unit/secret.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# tests/unit/secret.bats — consolidated coverage for the secret surface.
+#
+# Traceability:
+#   IT-04 — secret() (R-13)
+#   IT-05 — secret_get() (R-14)
+#   IT-06 — _secret_file_from_var name conversion (R-15)
+#   IT-07 — newsecret helper (covered in tests/unit/newsecret.bats; this
+#           file includes a smoke test that the helper is present and
+#           executable so the umbrella suite stays self-contained).
+#
+# Strategy: source dot_bashrc.d/executable_50-wrappers.sh, use mock_rbw
+# from tests/helpers/mocks.sh so rbw calls are deterministic and hermetic.
+# Every test uses BEGET_WARN to capture warnings rather than stderr.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+
+    WRAPPERS_SH="$REPO_ROOT/dot_bashrc.d/executable_50-wrappers.sh"
+    NEWSECRET="$REPO_ROOT/dot_local/bin/executable_newsecret"
+
+    export BEGET_WARN="$BATS_TEST_TMPDIR/warnings.log"
+    : >"$BEGET_WARN"
+
+    # shellcheck source=/dev/null
+    source "$WRAPPERS_SH"
+}
+
+# ---- IT-06: name conversion (R-15) -----------------------------------------
+
+@test "IT-06 positive: GITHUB_PAT -> github-pat" {
+    run _secret_file_from_var GITHUB_PAT
+    [ "$status" -eq 0 ]
+    [ "$output" = "github-pat" ]
+}
+
+@test "IT-06 positive: multi-component name lowercases and dashes" {
+    run _secret_file_from_var ANALOGIC_GITLAB_TOKEN
+    [ "$status" -eq 0 ]
+    [ "$output" = "analogic-gitlab-token" ]
+}
+
+@test "IT-06 negative: empty input fails" {
+    run _secret_file_from_var ""
+    [ "$status" -ne 0 ]
+}
+
+# ---- IT-04: secret() lazy materialization (R-13) ---------------------------
+
+@test "IT-04 positive: materializes from rbw when VAR is empty" {
+    mock_rbw ok "pat-xyz"
+    unset GITHUB_PAT
+    secret GITHUB_PAT
+    [ "$GITHUB_PAT" = "pat-xyz" ]
+}
+
+@test "IT-04 positive: idempotent when VAR already set (R-13)" {
+    # Even a broken rbw must not be invoked when VAR is populated.
+    mock_rbw missing
+    export GITHUB_PAT="preexisting"
+    run secret GITHUB_PAT
+    [ "$status" -eq 0 ]
+    [ "$GITHUB_PAT" = "preexisting" ]
+    [ ! -s "$BEGET_WARN" ]
+}
+
+@test "IT-04 negative: missing rbw item -> return 1 + warning" {
+    mock_rbw missing
+    unset GITHUB_PAT
+    run secret GITHUB_PAT
+    [ "$status" -eq 1 ]
+    grep -q 'rbw get' "$BEGET_WARN"
+}
+
+@test "IT-04 negative: rbw locked -> return 1" {
+    mock_rbw locked
+    unset GITHUB_PAT
+    run secret GITHUB_PAT
+    [ "$status" -eq 1 ]
+}
+
+@test "IT-04 negative: missing VAR arg -> usage error" {
+    run secret
+    [ "$status" -eq 1 ]
+    grep -q 'usage' "$BEGET_WARN"
+}
+
+# ---- IT-05: secret_get() prints without mutating env (R-14) ----------------
+
+@test "IT-05 positive: prints value on stdout" {
+    mock_rbw ok "hello"
+    run secret_get any-item
+    [ "$status" -eq 0 ]
+    [ "$output" = "hello" ]
+}
+
+@test "IT-05 positive: does not mutate env (R-14)" {
+    mock_rbw ok "hello"
+    unset GITHUB_PAT
+    out="$(secret_get github-pat)"
+    [ "$out" = "hello" ]
+    [ -z "${GITHUB_PAT:-}" ]
+}
+
+@test "IT-05 negative: missing item -> return 1" {
+    mock_rbw missing
+    run secret_get nope
+    [ "$status" -eq 1 ]
+}
+
+@test "IT-05 negative: missing item arg -> usage error" {
+    run secret_get
+    [ "$status" -eq 1 ]
+    grep -q 'usage' "$BEGET_WARN"
+}
+
+# ---- IT-07 smoke: newsecret helper is present and executable ---------------
+# Full behavioral coverage lives in tests/unit/newsecret.bats; this smoke
+# test ensures the umbrella suite fails loudly if the helper disappears.
+
+@test "IT-07 smoke: newsecret helper exists and is executable" {
+    [ -x "$NEWSECRET" ]
+}


### PR DESCRIPTION
## Summary

Adds the unit test layer called for by Story #26: new `tests/unit/*.bats` files for OS detection edge cases and the secret surface (IT-04/IT-05/IT-06/IT-07), plus extends `tests/helpers/mocks.sh` with a `mock_rbw` helper so secret tests can exercise the real `wrappers.sh` code without touching the host's `rbw` or vault state.

## Changes

- `tests/helpers/mocks.sh` — new `mock_rbw(behavior, value)` factory. Writes a deterministic fake `rbw` binary under `$BATS_TEST_TMPDIR/shim-rbw/rbw`, points `BEGET_RBW_CMD` at it, and logs every invocation to `$BATS_TEST_TMPDIR/rbw-calls.log`. Four behaviors: `ok`, `missing`, `locked`, `unreachable`.
- `tests/unit/os-detection.bats` — 11 tests covering `source_os_release` quoting variants and `die_if_unsupported_os` boundary cases (Rocky 10, Ubuntu 26.04, Fedora, CentOS, AlmaLinux).
- `tests/unit/secret.bats` — 13 tests: IT-04 `secret()` lazy materialization + idempotency (R-13), IT-05 `secret_get()` no-env-mutation (R-14), IT-06 `_secret_file_from_var` name conversion (R-15), IT-07 `newsecret` presence smoke.

## Linked Issues

Closes #26

## Test Plan

- [x] `bats tests/unit` — 216/216 pass locally
- [x] `shellcheck tests/helpers/mocks.sh` clean
- [x] `shfmt -i 4 -ci -d tests/helpers/mocks.sh` clean
- [x] trivy HIGH/CRITICAL: 0 findings
- [x] Empirical verification of `mock_rbw` shim generation (unquoted heredoc interpolates `$value` correctly; runtime shim prints expected value)
- [ ] CI green on this PR

## Code Review Disposition

`feature-dev:code-reviewer` raised 2 findings; both declined with rationale:

1. *"Single-quoted `$value` won't interpolate"* — DECLINED. In an unquoted `<<EOF` heredoc, single quotes are literal characters, not shell syntax markers. Empirically verified: the generated shim has `printf '%s' 'pat-xyz'` (correct) and prints `pat-xyz` at runtime. All 216 tests pass.
2. *"die_if_unsupported_os subshell env-state isolation"* — DECLINED. Reviewer acknowledged this is "not a current failure" and a "lurking" issue only if someone adds env-state assertions to the test bodies. Current tests assert only `$status` and `$output`, so the structure is hermetic.