### PR TITLE
feat(tests): E2E smoke suite — 8 Docker-isolated installer tests

### DIFF
--- a/scripts/ci/run-e2e.sh
+++ b/scripts/ci/run-e2e.sh
@@ -39,9 +39,19 @@ if [[ ${#scripts[@]} -eq 0 ]]; then
     exit 0
 fi
 
+# Distro filter: a script whose filename contains `-ubuntu-` runs only on
+# ubuntu* images; `-rocky-` runs only on rocky* images; everything else
+# runs on both. The convention is part of the filename so filtering stays
+# obvious at the call site.
+distro_family="${distro%%[0-9]*}"
+
 fail=0
 for s in "${scripts[@]}"; do
     name="$(basename "$s" .sh)"
+    case "$name" in
+        *-ubuntu-*) [[ "$distro_family" == "ubuntu" ]] || { echo "--- $name skipped on $distro ---"; continue; } ;;
+        *-rocky-*)  [[ "$distro_family" == "rocky"  ]] || { echo "--- $name skipped on $distro ---"; continue; } ;;
+    esac
     printf '\n=== %s on %s ===\n' "$name" "$distro"
     # No --privileged: the e2e scripts under tests/e2e/ don't touch systemd or
     # devices. If a future test needs a specific capability, add it narrowly

--- a/scripts/ci/run-e2e.sh
+++ b/scripts/ci/run-e2e.sh
@@ -46,7 +46,11 @@ for s in "${scripts[@]}"; do
     # No --privileged: the e2e scripts under tests/e2e/ don't touch systemd or
     # devices. If a future test needs a specific capability, add it narrowly
     # (--cap-add=...) with justification rather than re-enabling --privileged.
-    if ! docker run --rm -v "$PWD:/src" -w /src "$image" bash "$s"; then
+    # --user matches host uid/gid so JUnit writes to the bind-mounted
+    # tests/results/ succeed on CI runners (workspace uid != container uid).
+    # The non-root path (R-03) relies on euid != 0, which any non-zero uid
+    # satisfies; e2e-08 stubs current_euid() rather than using the real uid.
+    if ! docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/src" -w /src "$image" bash "$s"; then
         fail=1
     fi
 done

--- a/tests/e2e/Dockerfile.rocky9
+++ b/tests/e2e/Dockerfile.rocky9
@@ -1,0 +1,28 @@
+# Dockerfile.rocky9 -- E2E base image (Rocky Linux 9).
+#
+# RPM-family counterpart to Dockerfile.ubuntu24. Verifies the Rocky
+# branch of lib/platform.sh's dispatch logic. Minimal tooling only;
+# everything else comes from the test harness.
+
+FROM rockylinux:9
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN dnf install -yq \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        sudo \
+        tzdata
+
+# Install chezmoi at a pinned version.
+RUN curl -fsSL get.chezmoi.io | sh -s -- -b /usr/local/bin -t v2.55.0
+
+RUN useradd -m -s /bin/bash -u 1000 beget \
+    && printf 'beget ALL=(ALL) NOPASSWD: ALL\n' >/etc/sudoers.d/beget
+
+USER beget
+WORKDIR /home/beget/src

--- a/tests/e2e/Dockerfile.rocky9
+++ b/tests/e2e/Dockerfile.rocky9
@@ -9,7 +9,9 @@ FROM rockylinux:9
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-RUN dnf install -yq \
+# --allowerasing lets dnf swap the stock curl-minimal for the full curl
+# package (they both provide /usr/bin/curl but conflict on install).
+RUN dnf install --allowerasing -yq \
         bash \
         ca-certificates \
         curl \

--- a/tests/e2e/Dockerfile.ubuntu24
+++ b/tests/e2e/Dockerfile.ubuntu24
@@ -1,0 +1,41 @@
+# Dockerfile.ubuntu24 -- E2E base image (Ubuntu 24.04).
+#
+# Provides the minimum tooling a beget E2E test needs to exercise
+# install.sh and chezmoi's render path. We deliberately pre-install
+# chezmoi + rbw + the shell chain so individual E2E scripts don't each
+# pay the apt-install tax; every container is ephemeral so tests stay
+# independent (no shared state per spec AC).
+#
+# Test-only mock rbw is injected by run-e2e.sh as a bind-mounted PATH
+# override; we don't bake it in here so production and test images
+# diverge only via PATH.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN apt-get update -qq \
+    && apt-get install -yq --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        sudo \
+        shellcheck \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install chezmoi at a pinned version. We skip rbw — tests that need it
+# install a shim in tests/e2e/fixtures/.
+RUN curl -fsSL get.chezmoi.io | sh -s -- -b /usr/local/bin -t v2.55.0
+
+# Create an unprivileged user matching the spec's non-root constraint
+# (R-03). Uid 1000 is the conventional first-user uid on Ubuntu images.
+RUN useradd -m -s /bin/bash -u 1000 beget \
+    && printf 'beget ALL=(ALL) NOPASSWD: ALL\n' >/etc/sudoers.d/beget
+
+USER beget
+WORKDIR /home/beget/src

--- a/tests/e2e/Dockerfile.ubuntu24
+++ b/tests/e2e/Dockerfile.ubuntu24
@@ -33,8 +33,13 @@ RUN apt-get update -qq \
 RUN curl -fsSL get.chezmoi.io | sh -s -- -b /usr/local/bin -t v2.55.0
 
 # Create an unprivileged user matching the spec's non-root constraint
-# (R-03). Uid 1000 is the conventional first-user uid on Ubuntu images.
-RUN useradd -m -s /bin/bash -u 1000 beget \
+# (R-03). The stock ubuntu:24.04 image ships a default `ubuntu` user at
+# uid 1000, so remove it before reclaiming that uid for `beget`. At
+# runtime `scripts/ci/run-e2e.sh` overrides USER via --user to match the
+# host uid; this Dockerfile user exists mostly for direct `docker run`
+# use during development.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd -m -s /bin/bash -u 1000 beget \
     && printf 'beget ALL=(ALL) NOPASSWD: ALL\n' >/etc/sudoers.d/beget
 
 USER beget

--- a/tests/e2e/_lib.sh
+++ b/tests/e2e/_lib.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# tests/e2e/_lib.sh -- shared helpers for E2E tests.
+#
+# NOTE: Tests source this under `set -uo pipefail` (no -e). Each test
+# wraps its body in `run_test() { ... }` and checks the return value
+# of run_test. Every assertion short-circuits via `|| return 1` so a
+# failure actually short-circuits the test body.
+#
+# Provides:
+#   assert_eq      -- fail the test when two values differ
+#   assert_match   -- fail when a string doesn't match a regex
+#   emit_junit     -- write a single-testcase JUnit XML file
+#   with_mock_rbw  -- install a mock rbw on PATH (ok|missing modes)
+#
+# Tests are intended to run both inside a container (invoked by
+# scripts/ci/run-e2e.sh) and directly from a developer workstation for
+# debugging. They must be hermetic: no persistent state outside the
+# TEST_WORKDIR that the runner provides.
+
+set -uo pipefail
+
+# TEST_WORKDIR and TEST_NAME are provided by the invoker. Fall back to
+# temp-directory defaults for direct invocation.
+TEST_WORKDIR="${TEST_WORKDIR:-$(mktemp -d)}"
+TEST_NAME="${TEST_NAME:-$(basename "${BASH_SOURCE[1]:-$0}" .sh)}"
+TEST_RESULTS_DIR="${TEST_RESULTS_DIR:-tests/results}"
+mkdir -p "$TEST_RESULTS_DIR"
+
+_assert_fail() {
+    printf '  ASSERT FAILED: %s\n' "$*" >&2
+    return 1
+}
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="${3:-}"
+    if [[ "$actual" != "$expected" ]]; then
+        _assert_fail "${msg:-expected}='$expected' got='$actual'"
+        return 1
+    fi
+}
+
+assert_ne() {
+    local actual="$1" unexpected="$2" msg="${3:-}"
+    if [[ "$actual" == "$unexpected" ]]; then
+        _assert_fail "${msg:-value}='$actual' matched forbidden '$unexpected'"
+        return 1
+    fi
+}
+
+assert_match() {
+    local haystack="$1" regex="$2" msg="${3:-}"
+    if [[ ! "$haystack" =~ $regex ]]; then
+        _assert_fail "${msg:-regex mismatch}: needle='$regex' hay='${haystack:0:200}'"
+        return 1
+    fi
+}
+
+# emit_junit <status> <duration_sec> [failure_message]
+# status: pass | fail
+emit_junit() {
+    local status="$1" duration="$2" failure="${3:-}"
+    local out="$TEST_RESULTS_DIR/${TEST_NAME}.xml"
+    local ts cases
+    ts="$(date -u +%Y-%m-%dT%H:%M:%S)"
+
+    if [[ "$status" == "pass" ]]; then
+        cases='<testcase classname="beget.e2e" name="'"$TEST_NAME"'" time="'"$duration"'"/>'
+    else
+        # XML-escape the failure message for the attribute; CDATA body
+        # carries the raw text (tests control content, so `]]>` isn't
+        # a realistic concern). Backslash-escape `&` in replacements --
+        # bash parameter expansion treats unescaped `&` as "the matched
+        # text", so `${x//</&lt;}` yields `<lt;` not `&lt;`.
+        local escaped="${failure//&/\&amp;}"
+        escaped="${escaped//</\&lt;}"
+        escaped="${escaped//>/\&gt;}"
+        escaped="${escaped//\"/\&quot;}"
+        cases='<testcase classname="beget.e2e" name="'"$TEST_NAME"'" time="'"$duration"'"><failure message="'"$escaped"'"><![CDATA['"$failure"']]></failure></testcase>'
+    fi
+
+    cat >"$out" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="$TEST_NAME" tests="1" failures="$([[ "$status" == "fail" ]] && echo 1 || echo 0)" errors="0" skipped="0" timestamp="$ts">
+    $cases
+  </testsuite>
+</testsuites>
+EOF
+}
+
+# with_mock_rbw <mode>
+# mode: ok (returns valid JSON for any get) | missing (every get exits 1)
+with_mock_rbw() {
+    local mode="${1:-ok}"
+    local shim_dir="$TEST_WORKDIR/rbw-shim"
+    mkdir -p "$shim_dir"
+    cat >"$shim_dir/rbw" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    --version) echo "rbw 1.14.0 (e2e mock)"; exit 0 ;;
+    status) exit 0 ;;
+    login) exit 0 ;;
+    unlock) exit 0 ;;
+    get)
+        shift
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --raw|--field|--full) shift ;;
+                *) break ;;
+            esac
+        done
+        item="${1:-}"
+        if [[ "${E2E_RBW_MODE:-ok}" = "missing" ]]; then
+            echo "rbw: no item '$item'" >&2
+            exit 1
+        fi
+        case "$item" in
+            ssh-id-*)
+                printf '{"name":"%s","fields":[{"name":"privateKey","value":"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAAAMOCK\\n-----END OPENSSH PRIVATE KEY-----\\n"},{"name":"publicKey","value":"ssh-ed25519 AAAAMOCK %s"}]}\n' "$item" "$item"
+                ;;
+            aws-*)
+                printf '{"name":"%s","data":{"username":"AKIAMOCK","password":"SECRETMOCK/AKIAMOCK"},"fields":[]}\n' "$item"
+                ;;
+            *)
+                printf 'mock-value-for-%s\n' "$item"
+                ;;
+        esac
+        exit 0
+        ;;
+    *) exit 0 ;;
+esac
+EOF
+    chmod +x "$shim_dir/rbw"
+    export E2E_RBW_MODE="$mode"
+    export PATH="$shim_dir:$PATH"
+}
+
+# Invoke install.sh with preflight-only semantics: source it with
+# BEGET_INSTALL_SOURCED=1 so main() does not execute, then call
+# individual functions directly. Callers get access to parse_flags,
+# preflight, install_prereqs, etc.
+source_install() {
+    local repo="${1:?repo path required}"
+    export BEGET_INSTALL_SOURCED=1
+    # install.sh defers sourcing lib/platform.sh until main(); since
+    # we skip main(), bring platform.sh in directly so preflight /
+    # install_prereqs have source_os_release + friends available.
+    # shellcheck source=/dev/null
+    source "$repo/lib/platform.sh"
+    # shellcheck source=/dev/null
+    source "$repo/install.sh"
+}

--- a/tests/e2e/e2e-01-fresh-ubuntu-minimal.sh
+++ b/tests/e2e/e2e-01-fresh-ubuntu-minimal.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-01-fresh-ubuntu-minimal.sh -- E2E-01.
+#
+# Requirement: R-01, R-06, R-30 -- `install.sh --role=minimal --skip-secrets`
+# completes on Ubuntu 24.04.
+#
+# Strategy: source install.sh with BEGET_INSTALL_SOURCED=1 (so main()
+# doesn't auto-run), call parse_flags + preflight with DRY_RUN=1 to
+# avoid touching the host, assert the resolved role is `minimal` and
+# that skip_secrets is set. The Dockerfile.ubuntu24 guarantees the OS
+# identity; real package installs stay out of scope (the runner image
+# already has chezmoi + curl + git).
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+run_test() {
+    source_install "$REPO" || return 1
+    parse_flags --role=minimal --skip-secrets --dry-run || return 1
+
+    assert_eq "$ROLE" "minimal" "role" || return 1
+    assert_eq "$SKIP_SECRETS" "1" "skip_secrets" || return 1
+    assert_eq "$DRY_RUN" "1" "dry_run" || return 1
+
+    preflight || return 1
+    assert_eq "$OS_ID" "ubuntu" "os_id" || return 1
+    assert_eq "$OS_MAJOR_VERSION" "24" "os_major" || return 1
+
+    # install_prereqs in dry-run mode must emit a pkg list but not
+    # actually invoke apt.
+    local out
+    out="$(install_prereqs 2>&1)" || return 1
+    assert_match "$out" "would pkg_install" "install_prereqs dry-run marker" || return 1
+}
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-01 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-01 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/e2e/e2e-02-fresh-ubuntu-workstation.sh
+++ b/tests/e2e/e2e-02-fresh-ubuntu-workstation.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-02-fresh-ubuntu-workstation.sh -- E2E-02.
+#
+# Requirement: R-30, R-33 -- `install.sh --role=workstation --skip-secrets`
+# completes on Ubuntu 24.04.
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+run_test() {
+    source_install "$REPO" || return 1
+    parse_flags --role=workstation --skip-secrets --dry-run || return 1
+
+    assert_eq "$ROLE" "workstation" || return 1
+    assert_eq "$SKIP_SECRETS" "1" || return 1
+
+    preflight || return 1
+    assert_eq "$OS_ID" "ubuntu" || return 1
+
+    # Workstation role should include pinentry-gnome3 if GNOME, else
+    # base list only. XDG_CURRENT_DESKTOP is unset in the container so
+    # is_gnome returns 1 and we should NOT see pinentry-gnome3.
+    unset XDG_CURRENT_DESKTOP
+    local out
+    out="$(install_prereqs 2>&1)" || return 1
+    assert_match "$out" "chezmoi" "prereqs mention chezmoi" || return 1
+
+    # Force GNOME branch to confirm pinentry-gnome3 gets added.
+    # shellcheck disable=SC2034
+    export XDG_CURRENT_DESKTOP="GNOME"
+    local out2
+    out2="$(install_prereqs 2>&1)" || return 1
+    assert_match "$out2" "pinentry-gnome3" "GNOME branch adds pinentry-gnome3" || return 1
+}
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-02 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-02 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/e2e/e2e-03-fresh-rocky-workstation.sh
+++ b/tests/e2e/e2e-03-fresh-rocky-workstation.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-03-fresh-rocky-workstation.sh -- E2E-03.
+#
+# Requirement: R-02 -- `install.sh --role=workstation --skip-secrets`
+# completes on Rocky 9.
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+run_test() {
+    source_install "$REPO" || return 1
+    parse_flags --role=workstation --skip-secrets --dry-run || return 1
+
+    preflight || return 1
+    assert_eq "$OS_ID" "rocky" "os_id (expect rocky on Dockerfile.rocky9)" || return 1
+    assert_eq "$OS_MAJOR_VERSION" "9" "os_major" || return 1
+
+    local out
+    out="$(install_prereqs 2>&1)" || return 1
+    # Dry-run marker should appear -- the pkg list itself may vary.
+    assert_match "$out" "pkg_install" "install_prereqs dispatched" || return 1
+}
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-03 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-03 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/e2e/e2e-04-mock-rbw-materialize.sh
+++ b/tests/e2e/e2e-04-mock-rbw-materialize.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-04-mock-rbw-materialize.sh -- E2E-04.
+#
+# Requirement: R-17, R-18 -- SSH / AWS credentials materialize from
+# mocked rbw via chezmoi execute-template. We render the actual
+# templates (private_dot_ssh/private_id_ed25519.tmpl, private_dot_aws/
+# credentials.tmpl) against our mock rbw and assert the rendered
+# content has the mock markers.
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+run_test() (
+    with_mock_rbw ok
+    cd "$REPO" || return 1
+
+    local ssh_tpl="$REPO/private_dot_ssh/private_id_ed25519.tmpl"
+    if [[ ! -f "$ssh_tpl" ]]; then
+        _assert_fail "SSH template missing: $ssh_tpl"
+        return 1
+    fi
+    local rendered
+    rendered="$(chezmoi execute-template --source "$REPO" <"$ssh_tpl")" || return 1
+    assert_match "$rendered" "OPENSSH PRIVATE KEY" "SSH key materialized" || return 1
+    assert_match "$rendered" "AAAAMOCK" "mock marker present" || return 1
+
+    local aws_tpl="$REPO/private_dot_aws/credentials.tmpl"
+    if [[ -f "$aws_tpl" ]]; then
+        local rendered2
+        rendered2="$(chezmoi execute-template --source "$REPO" <"$aws_tpl")" || return 1
+        assert_match "$rendered2" "aws_access_key_id = AKIAMOCK" "AWS key materialized" || return 1
+    fi
+)
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-04 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-04 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/e2e/e2e-05-rerun-idempotency.sh
+++ b/tests/e2e/e2e-05-rerun-idempotency.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-05-rerun-idempotency.sh -- E2E-05.
+#
+# Requirement: R-07, R-08 -- re-running install.sh on an already-
+# bootstrapped container is safe. We simulate this at the function
+# level: parse_flags and preflight twice with the same dry-run inputs
+# must leave state consistent.
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+run_test() {
+    source_install "$REPO" || return 1
+
+    # First pass.
+    parse_flags --role=minimal --skip-secrets --dry-run || return 1
+    preflight || return 1
+    local role1="$ROLE"
+    local skip1="$SKIP_SECRETS"
+    local os1="$OS_ID"
+
+    # Second pass with the same inputs.
+    parse_flags --role=minimal --skip-secrets --dry-run || return 1
+    preflight || return 1
+    assert_eq "$ROLE" "$role1" "role stable across re-runs" || return 1
+    assert_eq "$SKIP_SECRETS" "$skip1" "skip_secrets stable" || return 1
+    assert_eq "$OS_ID" "$os1" "os_id stable" || return 1
+
+    # install_prereqs should be idempotent in dry-run too.
+    local out1 out2
+    out1="$(install_prereqs 2>&1)" || return 1
+    out2="$(install_prereqs 2>&1)" || return 1
+    assert_eq "$out1" "$out2" "install_prereqs output stable across re-runs" || return 1
+}
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-05 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-05 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/e2e/e2e-06-template-change-isolation.sh
+++ b/tests/e2e/e2e-06-template-change-isolation.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-06-template-change-isolation.sh -- E2E-06.
+#
+# Requirement: R-08, R-19 -- mutating a single template and re-rendering
+# only affects that template's output, not others.
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+run_test() (
+    with_mock_rbw ok
+    cd "$REPO" || return 1
+
+    local gitconfig_tpl="$REPO/dot_gitconfig.tmpl"
+    local aws_tpl="$REPO/private_dot_aws/credentials.tmpl"
+
+    if [[ ! -f "$gitconfig_tpl" || ! -f "$aws_tpl" ]]; then
+        _assert_fail "required templates missing"
+        return 1
+    fi
+
+    local before_aws before_git after_git after_aws
+    before_aws="$(chezmoi execute-template --source "$REPO" <"$aws_tpl")" || return 1
+
+    # Work on a copy of the gitconfig template under TEST_WORKDIR
+    # so the repo stays clean.
+    local tmp_tpl="$TEST_WORKDIR/dot_gitconfig.tmpl"
+    cp "$gitconfig_tpl" "$tmp_tpl" || return 1
+    printf '\n# e2e sentinel %s\n' "$(date +%s)" >>"$tmp_tpl"
+
+    before_git="$(chezmoi execute-template --source "$REPO" <"$gitconfig_tpl")" || return 1
+    after_git="$(chezmoi execute-template --source "$REPO" <"$tmp_tpl")" || return 1
+    after_aws="$(chezmoi execute-template --source "$REPO" <"$aws_tpl")" || return 1
+
+    assert_eq "$before_aws" "$after_aws" "AWS template unaffected by git tpl change" || return 1
+    assert_ne "$before_git" "$after_git" "git tpl change actually rendered differently" || return 1
+)
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-06 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-06 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/e2e/e2e-07-rbw-missing-graceful.sh
+++ b/tests/e2e/e2e-07-rbw-missing-graceful.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-07-rbw-missing-graceful.sh -- E2E-07.
+#
+# Requirement: R-23 -- when rbw reports a missing item, chezmoi apply
+# / execute-template fails with a clear error rather than silently
+# emitting garbage.
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+run_test() (
+    with_mock_rbw missing
+    cd "$REPO" || return 1
+
+    local ssh_tpl="$REPO/private_dot_ssh/private_id_ed25519.tmpl"
+    if [[ ! -f "$ssh_tpl" ]]; then
+        _assert_fail "SSH template missing: $ssh_tpl"
+        return 1
+    fi
+
+    # chezmoi execute-template should fail with non-zero and an
+    # error mentioning rbw (or the item name).
+    local out
+    if out="$(chezmoi execute-template --source "$REPO" <"$ssh_tpl" 2>&1)"; then
+        _assert_fail "chezmoi succeeded despite rbw missing: $out"
+        return 1
+    fi
+    assert_match "$out" "(rbw|no item|ssh-id-)" "error message references rbw" || return 1
+)
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-07 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-07 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/e2e/e2e-08-root-refusal.sh
+++ b/tests/e2e/e2e-08-root-refusal.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-08-root-refusal.sh -- E2E-08.
+#
+# Requirement: R-03 -- install.sh refuses to run as root without
+# --allow-root. We can run the test as a non-root user by stubbing
+# `current_euid` to return 0, since source_install exposes the
+# function for overriding.
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+run_test() {
+    source_install "$REPO" || return 1
+    parse_flags --role=minimal --skip-secrets || return 1
+
+    # Override current_euid to simulate uid 0 (invoked indirectly by
+    # preflight -- shellcheck can't see the dynamic dispatch).
+    # shellcheck disable=SC2317
+    current_euid() { echo 0; }
+
+    # preflight must abort with a non-zero exit and an error mentioning
+    # root / --allow-root.
+    local out
+    if out="$(preflight 2>&1)"; then
+        _assert_fail "preflight succeeded as fake-root without --allow-root"
+        return 1
+    fi
+    assert_match "$out" "(root|allow-root|R-03)" "preflight rejects root" || return 1
+
+    # With --allow-root the same euid-0 scenario must NOT trigger the
+    # root-refusal branch. ALLOW_ROOT is read by preflight() in
+    # install.sh.
+    # shellcheck disable=SC2034
+    ALLOW_ROOT=1
+    local out2 rc=0
+    out2="$(preflight 2>&1)" || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        _assert_fail "--allow-root: preflight still exited non-zero ($rc): $out2"
+        return 1
+    fi
+    if [[ "$out2" == *"refusing to run as root"* ]]; then
+        _assert_fail "--allow-root did not bypass R-03 refusal"
+        return 1
+    fi
+}
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-08 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-08 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1


### PR DESCRIPTION
## Summary

Implements Story #28: eight Docker-isolated E2E tests covering install.sh role dispatch, OS detection, secret materialization via mocked rbw, idempotency, template isolation, and root refusal. Slots into the `e2e-ubuntu` and `e2e-rocky` jobs wired up in #25.

## Changes

- `tests/e2e/_lib.sh` — assert helpers, JUnit emitter with XML-escaped attribute, `with_mock_rbw` shim, `source_install` harness
- `tests/e2e/Dockerfile.ubuntu24` + `Dockerfile.rocky9` — pinned chezmoi v2.55.0, non-root `beget` user
- `tests/e2e/e2e-0{1..8}-*.sh` — 8 smoke tests mapped to R-requirements (see each file's header)
- `scripts/ci/run-e2e.sh` — `--user $(id -u):$(id -g)` so the container process writes the JUnit artifact to the bind-mounted workspace without uid collisions on hosted runners

## Linked Issues

Closes #28

## Test Plan

- [x] `shellcheck tests/e2e/*.sh scripts/ci/run-e2e.sh` — clean
- [x] `bash tests/e2e/e2e-01-fresh-ubuntu-minimal.sh` — PASS
- [x] `bash tests/e2e/e2e-05-rerun-idempotency.sh` — PASS
- [x] `bash tests/e2e/e2e-08-root-refusal.sh` — PASS
- [x] `emit_junit` escape verified with `"` `<` `>` `&` in failure messages
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [ ] Full E2E suite green in CI (both distros)