### PR TITLE
feat(tests): integration test suite (IT-01, IT-02, IT-03, IT-09)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
           path: tests/results/*.xml
           if-no-files-found: ignore
 
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/ci/install-lint-deps.sh
+      - run: ./scripts/ci/install-chezmoi.sh
+      - run: ./scripts/ci/run-integration.sh
+
   e2e-ubuntu:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: help bootstrap-test-deps lint apply-dry apply verify test-unit
+.PHONY: help bootstrap-test-deps lint apply-dry apply verify test-unit test-integration
 
 help:
 	@echo "beget — available targets:"
@@ -16,6 +16,7 @@ help:
 	@echo "  verify               chezmoi verify (reports drift)"
 	@echo "  bootstrap-test-deps  initialize the bats-core git submodule"
 	@echo "  test-unit            run bats-core unit tests"
+	@echo "  test-integration     run shellcheck, shfmt, chezmoi-render, header-comments (IT-01..IT-03,IT-09)"
 
 # ---- Linting ----------------------------------------------------------------
 # Shellcheck every bash file we own: the bootstrap entry, the sourced library,
@@ -53,3 +54,15 @@ bootstrap-test-deps:
 
 test-unit: bootstrap-test-deps
 	tests/bats/bin/bats tests/unit
+
+# ---- Integration tests (IT-01, IT-02, IT-03, IT-09) -------------------------
+# Runs each tests/integration/*.sh in turn. A failure in any one stops the
+# tier with a non-zero exit so CI surfaces the first offender clearly.
+test-integration:
+	@set -euo pipefail; \
+	for s in tests/integration/shellcheck.sh tests/integration/shfmt.sh \
+	          tests/integration/chezmoi-render.sh tests/integration/header-comments.sh; do \
+	    if [[ ! -x "$$s" ]]; then echo "MISSING: $$s" >&2; exit 1; fi; \
+	    echo "==> $$s"; \
+	    "$$s"; \
+	done

--- a/install.sh
+++ b/install.sh
@@ -88,12 +88,15 @@ parse_flags() {
     local arg
     for arg in "$@"; do
         case "$arg" in
-            --dry-run)       DRY_RUN=1 ;;
-            --role=*)        ROLE="${arg#--role=}" ;;
-            --skip-secrets)  SKIP_SECRETS=1 ;;
-            --allow-root)    ALLOW_ROOT=1 ;;
-            --help|-h)       usage; exit 0 ;;
-            *)               die "unknown flag: $arg (see --help)" ;;
+            --dry-run) DRY_RUN=1 ;;
+            --role=*) ROLE="${arg#--role=}" ;;
+            --skip-secrets) SKIP_SECRETS=1 ;;
+            --allow-root) ALLOW_ROOT=1 ;;
+            --help | -h)
+                usage
+                exit 0
+                ;;
+            *) die "unknown flag: $arg (see --help)" ;;
         esac
     done
 

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -63,10 +63,10 @@ pkg_install() {
     fi
 
     case "$OS_ID" in
-        ubuntu|debian)
+        ubuntu | debian)
             sudo apt-get install -y "$@"
             ;;
-        rocky|rhel|centos|almalinux|fedora)
+        rocky | rhel | centos | almalinux | fedora)
             sudo dnf install -y "$@"
             ;;
         *)
@@ -96,20 +96,20 @@ pkg_repo_add() {
     local yum_dir="${YUM_REPOS_DIR:-/etc/yum.repos.d}"
 
     case "$OS_ID" in
-        ubuntu|debian)
+        ubuntu | debian)
             local keyring_path="/usr/share/keyrings/${name}.gpg"
             local list_path="${apt_dir}/${name}.list"
             # Fetch keyring separately: a sourced library can't set -o pipefail,
             # so curl|gpg would silently swallow a curl failure and write an
             # empty keyring. Fail fast instead.
             local key_bytes
-            key_bytes=$(curl -fsSL "$keyring_url") \
-                || die "pkg_repo_add: failed to fetch keyring: $keyring_url"
+            key_bytes=$(curl -fsSL "$keyring_url") ||
+                die "pkg_repo_add: failed to fetch keyring: $keyring_url"
             printf '%s' "$key_bytes" | sudo gpg --dearmor -o "$keyring_path"
-            printf 'deb [signed-by=%s] %s\n' "$keyring_path" "$url" \
-                | sudo tee "$list_path" >/dev/null
+            printf 'deb [signed-by=%s] %s\n' "$keyring_path" "$url" |
+                sudo tee "$list_path" >/dev/null
             ;;
-        rocky|rhel|centos|almalinux|fedora)
+        rocky | rhel | centos | almalinux | fedora)
             local repo_path="${yum_dir}/${name}.repo"
             sudo curl -fsSL -o "$repo_path" "$url"
             sudo rpm --import "$keyring_url"

--- a/run_onchange_before_10-apt-repos.sh
+++ b/run_onchange_before_10-apt-repos.sh
@@ -77,7 +77,7 @@ install_keyring() {
     # under /etc/apt/keyrings/ are writable.
     local tmp_dearmored
     tmp_dearmored="$(mktemp)"
-    gpg --dearmor < "$tmp" > "$tmp_dearmored"
+    gpg --dearmor <"$tmp" >"$tmp_dearmored"
     "$BEGET_SUDO" install -m 0644 -T "$tmp_dearmored" "$dest_path"
     rm -f "$tmp" "$tmp_dearmored"
     return 0
@@ -96,7 +96,7 @@ write_sources_file() {
     tmp="$(mktemp)"
     # %s is the fully rendered sources line; callers template the dist name in.
     local rendered="${sources_line//\{\{DIST\}\}/$dist}"
-    printf 'deb [signed-by=%s] %s\n' "$keyring_path" "$rendered" > "$tmp"
+    printf 'deb [signed-by=%s] %s\n' "$keyring_path" "$rendered" >"$tmp"
     "$BEGET_SUDO" install -m 0644 -T "$tmp" "$dest"
     rm -f "$tmp"
 }

--- a/run_onchange_before_20-packages-common.sh
+++ b/run_onchange_before_20-packages-common.sh
@@ -89,7 +89,7 @@ main() {
             # minimal role gets only the survival-kit list, NOT common.
             install_from_list "${PACKAGE_DIR}/apt-packages-minimal.list"
             ;;
-        workstation|server)
+        workstation | server)
             install_from_list "$common_list"
             install_from_list "$role_list"
             ;;

--- a/run_onchange_before_50-tool-download-binaries.sh
+++ b/run_onchange_before_50-tool-download-binaries.sh
@@ -100,9 +100,9 @@ classify_artifact() {
     local url="$1"
     local lower="${url,,}"
     case "$lower" in
-        *.tar.gz|*.tgz) printf 'tar.gz' ;;
-        *.zip)          printf 'zip' ;;
-        *)              printf 'raw' ;;
+        *.tar.gz | *.tgz) printf 'tar.gz' ;;
+        *.zip) printf 'zip' ;;
+        *) printf 'raw' ;;
     esac
 }
 
@@ -151,7 +151,7 @@ install_aws_from_extracted() {
     fi
     "$installer" \
         --install-dir "${HOME}/.local/aws-cli" \
-        --bin-dir     "$BEGET_BIN_DIR" \
+        --bin-dir "$BEGET_BIN_DIR" \
         --update
 }
 
@@ -244,8 +244,8 @@ main() {
 
         # Idempotency: skip if the installed binary already reports the
         # expected version. Test seam BEGET_DRY_RUN forces re-install.
-        if [[ "${BEGET_DRY_RUN:-}" != "1" ]] \
-           && current_version_matches "$name" "$version"; then
+        if [[ "${BEGET_DRY_RUN:-}" != "1" ]] &&
+            current_version_matches "$name" "$version"; then
             printf 'tool-download: %s v%s already current, skipping\n' \
                 "$name" "$version" >&2
             continue

--- a/run_onchange_before_52-tool-pipx.sh
+++ b/run_onchange_before_52-tool-pipx.sh
@@ -35,9 +35,9 @@ beget_pipx_packages() {
 pipx_has_package() {
     local pkg="$1"
     # `pipx list --short` prints "<name> <version>" per line.
-    "$BEGET_PIPX" list --short 2>/dev/null \
-        | awk '{print $1}' \
-        | grep -Fxq "$pkg"
+    "$BEGET_PIPX" list --short 2>/dev/null |
+        awk '{print $1}' |
+        grep -Fxq "$pkg"
 }
 
 install_pipx_package() {

--- a/run_onchange_before_53-tool-uv.sh
+++ b/run_onchange_before_53-tool-uv.sh
@@ -28,9 +28,9 @@ beget_uv_packages() {
 uv_has_package() {
     local pkg="$1"
     # `uv tool list` prints one tool per line as "<name> v<ver>".
-    "$BEGET_UV" tool list 2>/dev/null \
-        | awk '{print $1}' \
-        | grep -Fxq "$pkg"
+    "$BEGET_UV" tool list 2>/dev/null |
+        awk '{print $1}' |
+        grep -Fxq "$pkg"
 }
 
 install_uv_package() {

--- a/run_onchange_before_55-tool-carbonyl.sh
+++ b/run_onchange_before_55-tool-carbonyl.sh
@@ -50,8 +50,8 @@ current_version_matches() {
 main() {
     install -d -m 0755 "$BEGET_BIN_DIR"
 
-    if [[ "${BEGET_CARBONYL_DRY_RUN:-}" != "1" ]] \
-       && current_version_matches; then
+    if [[ "${BEGET_CARBONYL_DRY_RUN:-}" != "1" ]] &&
+        current_version_matches; then
         printf 'tool-carbonyl: v%s already current, skipping\n' \
             "$BEGET_CARBONYL_VERSION" >&2
         return 0

--- a/run_onchange_before_workstation_70-gnome-keybinds.sh
+++ b/run_onchange_before_workstation_70-gnome-keybinds.sh
@@ -79,8 +79,8 @@ gset() {
 get_current_array() {
     # Returns current custom-keybindings array as a raw GSettings literal,
     # e.g. "@as []" or "['/a/', '/b/']". We just pass it back through.
-    "$BEGET_GSETTINGS" get "$CUSTOM_KEYS_SCHEMA" "$CUSTOM_KEYS_KEY" 2>/dev/null \
-        || printf "@as []"
+    "$BEGET_GSETTINGS" get "$CUSTOM_KEYS_SCHEMA" "$CUSTOM_KEYS_KEY" 2>/dev/null ||
+        printf "@as []"
 }
 
 array_contains_path() {
@@ -117,7 +117,7 @@ write_binding_triple() {
     local slug="$1" name="$2" command="$3" shortcut="$4"
     local path="${CUSTOM_KEYS_PREFIX}/${slug}/"
     # Use the relocatable-schema-at-path form: `gsettings set <schema>:<path>`
-    gset set "${BINDING_SCHEMA}:${path}" name    "$name"
+    gset set "${BINDING_SCHEMA}:${path}" name "$name"
     gset set "${BINDING_SCHEMA}:${path}" command "$command"
     gset set "${BINDING_SCHEMA}:${path}" binding "$shortcut"
 }
@@ -127,8 +127,8 @@ read_binding_name() {
     # GSettings emits strings wrapped in single quotes, e.g. 'beget:cheet-tldr'.
     # Strip only the wrapping pair (not embedded apostrophes); `tr -d` would
     # flatten a binding name that legitimately contained "'".
-    "$BEGET_GSETTINGS" get "${BINDING_SCHEMA}:${path}" name 2>/dev/null \
-        | sed "s/^'//; s/'\$//" || printf ''
+    "$BEGET_GSETTINGS" get "${BINDING_SCHEMA}:${path}" name 2>/dev/null |
+        sed "s/^'//; s/'\$//" || printf ''
 }
 
 install_binding() {
@@ -159,8 +159,8 @@ install_binding() {
 }
 
 main() {
-    if ! command -v "$BEGET_GSETTINGS" >/dev/null 2>&1 \
-       && [[ "${BEGET_DRY_RUN:-}" != "1" ]]; then
+    if ! command -v "$BEGET_GSETTINGS" >/dev/null 2>&1 &&
+        [[ "${BEGET_DRY_RUN:-}" != "1" ]]; then
         printf 'gnome-keybinds: %s not on PATH; skipping (non-GNOME host?)\n' \
             "$BEGET_GSETTINGS" >&2
         return 0

--- a/scripts/ci/run-e2e.sh
+++ b/scripts/ci/run-e2e.sh
@@ -49,8 +49,14 @@ fail=0
 for s in "${scripts[@]}"; do
     name="$(basename "$s" .sh)"
     case "$name" in
-        *-ubuntu-*) [[ "$distro_family" == "ubuntu" ]] || { echo "--- $name skipped on $distro ---"; continue; } ;;
-        *-rocky-*)  [[ "$distro_family" == "rocky"  ]] || { echo "--- $name skipped on $distro ---"; continue; } ;;
+        *-ubuntu-*) [[ "$distro_family" == "ubuntu" ]] || {
+            echo "--- $name skipped on $distro ---"
+            continue
+        } ;;
+        *-rocky-*) [[ "$distro_family" == "rocky" ]] || {
+            echo "--- $name skipped on $distro ---"
+            continue
+        } ;;
     esac
     printf '\n=== %s on %s ===\n' "$name" "$distro"
     # No --privileged: the e2e scripts under tests/e2e/ don't touch systemd or

--- a/scripts/ci/run-integration.sh
+++ b/scripts/ci/run-integration.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# scripts/ci/run-integration.sh — integration test tier (IT-01, IT-02, IT-03, IT-09).
+#
+# Delegates to `make test-integration`, which runs each tests/integration/*.sh
+# in order: shellcheck.sh (IT-01), shfmt.sh (IT-02), chezmoi-render.sh (IT-03),
+# header-comments.sh (IT-09). A failure in any one fails this job.
+set -euo pipefail
+
+make test-integration

--- a/scripts/migrate-secrets.sh
+++ b/scripts/migrate-secrets.sh
@@ -130,7 +130,7 @@ while [[ $# -gt 0 ]]; do
             SOURCE_DIR="${1#--source=}"
             shift
             ;;
-        --help|-h)
+        --help | -h)
             usage
             exit 0
             ;;
@@ -189,7 +189,7 @@ for file in "${files[@]}"; do
     name="$(basename "$file")"
     # Skip hidden dotfiles and any obvious non-secret detritus.
     case "$name" in
-        .*|*.swp|*.bak)
+        .* | *.swp | *.bak)
             log "skip $name (ignored pattern)"
             count_skipped=$((count_skipped + 1))
             continue

--- a/tests/integration/chezmoi-render.sh
+++ b/tests/integration/chezmoi-render.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# tests/integration/chezmoi-render.sh -- IT-03.
+#
+# Render every *.tmpl through `chezmoi execute-template` with the repo
+# as chezmoi's source directory (so `include` resolves relatively) and a
+# deterministic mock rbw / rbwFields surface so templates that pull
+# secrets don't need real Vaultwarden access. Any render error (missing
+# fixture, bad template syntax, unresolvable function call) is a
+# failure. Reports offending tmpl + the chezmoi error output.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT" || {
+    echo "cannot cd to $REPO_ROOT" >&2
+    exit 2
+}
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+    echo "chezmoi not installed" >&2
+    exit 2
+fi
+
+# Mock rbw shim -- returns a deterministic JSON blob matching what
+# chezmoi's rbw/rbwFields functions feed off. Writes under a scratch
+# dir on PATH so the real rbw (if installed) doesn't get invoked.
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+cat >"$scratch/rbw" <<'EOF'
+#!/usr/bin/env bash
+# Mock rbw for chezmoi-render IT-03.
+# Usage patterns we must satisfy:
+#   rbw get --raw <item>       -> bare secret value
+#   rbw get <item>             -> bare secret value (legacy)
+#   rbw get --field <f> <item> -> field value
+#   rbw --version              -> version string
+case "${1:-}" in
+    --version) echo "rbw 1.14.0 (mock)"; exit 0 ;;
+    get)
+        shift
+        # Consume --raw / --field <f>
+        field=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --raw) shift ;;
+                --field) field="$2"; shift 2 ;;
+                *) break ;;
+            esac
+        done
+        item="${1:-}"
+        if [[ -z "$item" ]]; then exit 1; fi
+        # For key-shaped items, emit a JSON object chezmoi rbwFields
+        # consumers can traverse. Otherwise emit a plain value.
+        case "$item" in
+            ssh-id-*)
+                # chezmoi's rbwFields converts `fields` array into a
+                # map keyed by field.name. The bare privateKey / publicKey
+                # keys on the returned map must therefore appear as
+                # `fields[]` entries.
+                cat <<JSON
+{"name":"$item","notes":"","fields":[{"name":"privateKey","value":"-----BEGIN OPENSSH PRIVATE KEY-----\nAAAAMOCK\n-----END OPENSSH PRIVATE KEY-----\n"},{"name":"publicKey","value":"ssh-ed25519 AAAAMOCK $item"}]}
+JSON
+                ;;
+            aws-*)
+                # Templates use e.g. `(rbw "aws-default").data.username`;
+                # match that shape.
+                cat <<JSON
+{"name":"$item","notes":"","data":{"username":"AKIAMOCK","password":"SECRETMOCK/AKIAMOCK"},"fields":[]}
+JSON
+                ;;
+            *)
+                printf 'mock-value-for-%s\n' "$item"
+                ;;
+        esac
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+EOF
+chmod +x "$scratch/rbw"
+
+# chezmoi's rbw/rbwFields helpers shell out to the `rbw` binary on
+# PATH; put our shim first.
+export PATH="$scratch:$PATH"
+
+shopt -s nullglob globstar
+
+# Collect every *.tmpl file the repo ships. Exclude the bats submodule
+# and any scratch tree.
+mapfile -t templates < <(find . -name '*.tmpl' \
+    -not -path './tests/bats/*' \
+    -not -path './.git/*' \
+    -not -path "$scratch/*" | sort)
+
+if [[ ${#templates[@]} -eq 0 ]]; then
+    echo "chezmoi-render: no templates found"
+    exit 0
+fi
+
+# Use the repo as chezmoi's source dir so include "path" resolves.
+export CHEZMOI_SOURCE_DIR="$REPO_ROOT"
+
+fail=0
+errlog="$scratch/chezmoi.err"
+for tpl in "${templates[@]}"; do
+    rel="${tpl#./}"
+    if ! chezmoi execute-template --source "$REPO_ROOT" <"$tpl" >/dev/null 2>"$errlog"; then
+        printf 'FAIL: %s\n' "$rel" >&2
+        sed "s#^#  #" "$errlog" >&2 || true
+        fail=1
+    fi
+done
+exit "$fail"

--- a/tests/integration/header-comments.sh
+++ b/tests/integration/header-comments.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# tests/integration/header-comments.sh — IT-09.
+#
+# Every run_onchange_* script must begin with:
+#   1. A shebang line (#!/usr/bin/env bash or #!/bin/bash) or a chezmoi
+#      template preamble for *.tmpl files.
+#   2. A comment line naming the script's path.
+#   3. At least one comment line describing intent (R-44).
+#
+# Fails with file:line on first violation per file.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT" || {
+    echo "cannot cd to $REPO_ROOT" >&2
+    exit 2
+}
+
+shopt -s nullglob
+scripts=(run_onchange_*)
+if [[ ${#scripts[@]} -eq 0 ]]; then
+    echo "header-comments: no run_onchange_* scripts found"
+    exit 0
+fi
+
+fail=0
+for s in "${scripts[@]}"; do
+    [[ -f "$s" ]] || continue
+
+    # Pull the first ~20 lines for inspection. Skip chezmoi template
+    # preambles ({{- /* ... */ -}} or `{{- if ... -}}`) when present.
+    header="$(sed -n '1,20p' "$s")"
+
+    # Check 1: must start with a shebang or a template directive.
+    first_line="$(sed -n '1p' "$s")"
+    case "$first_line" in
+        '#!/usr/bin/env bash' | '#!/bin/bash') ;;
+        '{{'*)
+            # chezmoi template with Go-template preamble ({{ ... }} or
+            # {{- ... -}}); shebang is inside the rendered body, not
+            # mandatory on line 1.
+            ;;
+        *)
+            printf '%s:1 FAIL: missing shebang or template preamble\n' "$s" >&2
+            fail=1
+            continue
+            ;;
+    esac
+
+    # Check 2: at least one comment line in the first 20 that mentions
+    # the file's path (either as written here or the rendered form).
+    base_name="$(basename "$s")"
+    base_no_tmpl="${base_name%.tmpl}"
+    if ! grep -qE "^#.*(${base_name}|${base_no_tmpl})" <<<"$header"; then
+        printf '%s:1 FAIL: header does not name the script (%s)\n' \
+            "$s" "$base_name" >&2
+        fail=1
+        continue
+    fi
+
+    # Check 3: at least one intent line — a `#` line that is not the
+    # shebang, not the filename line, and has substantive text (≥ 10
+    # chars after `#`). Signals the script explains why it exists.
+    intent_count=0
+    while IFS= read -r line; do
+        case "$line" in
+            '#!'*) continue ;;
+            '# '*)
+                payload="${line#\# }"
+                [[ ${#payload} -ge 10 ]] && intent_count=$((intent_count + 1))
+                ;;
+        esac
+    done <<<"$header"
+
+    if [[ "$intent_count" -lt 2 ]]; then
+        printf '%s:1 FAIL: header lacks intent description (R-44)\n' "$s" >&2
+        fail=1
+    fi
+done
+exit "$fail"

--- a/tests/integration/shellcheck.sh
+++ b/tests/integration/shellcheck.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# tests/integration/shellcheck.sh — IT-01.
+#
+# Run shellcheck across every *.sh under the repo (excluding the bats
+# submodule and vendored trees). Aggregates failures: one offender per
+# file is reported; the script exits non-zero if any file fails. Prints
+# file:line so failure output is copy-pastable.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT" || {
+    echo "cannot cd to $REPO_ROOT" >&2
+    exit 2
+}
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "shellcheck not installed" >&2
+    exit 2
+fi
+
+# Build the target list. Aligns with the existing `make lint` scope plus
+# CI and integration test scripts added by Story #27. We deliberately
+# SKIP dot_bashrc.d/*.sh (sourced fragments without shebangs) and *.tmpl
+# files (chezmoi-rendered, not raw bash).
+shopt -s nullglob globstar
+
+targets=()
+[[ -f install.sh ]] && targets+=(install.sh)
+targets+=(lib/*.sh)
+targets+=(scripts/**/*.sh)
+targets+=(tests/integration/*.sh)
+targets+=(tests/helpers/*.sh)
+
+# run_onchange_* files that are plain .sh (no .tmpl suffix) are pure bash.
+for f in run_onchange_*; do
+    [[ -f "$f" ]] || continue
+    case "$f" in
+        *.tmpl) ;; # chezmoi will render; skip shellcheck.
+        *) targets+=("$f") ;;
+    esac
+done
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "shellcheck: no files to check"
+    exit 0
+fi
+
+echo "shellcheck: $(printf '%s ' "${targets[@]}")"
+
+fail=0
+for f in "${targets[@]}"; do
+    [[ -f "$f" ]] || continue
+    if ! shellcheck "$f"; then
+        printf 'FAIL: %s\n' "$f" >&2
+        fail=1
+    fi
+done
+exit "$fail"

--- a/tests/integration/shfmt.sh
+++ b/tests/integration/shfmt.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# tests/integration/shfmt.sh -- IT-02.
+#
+# Run shfmt --diff over every *.sh in scope (same target list as the
+# integration shellcheck script). Any diff output is a failure --
+# formatting drift breaks the build.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT" || {
+    echo "cannot cd to $REPO_ROOT" >&2
+    exit 2
+}
+
+if ! command -v shfmt >/dev/null 2>&1; then
+    echo "shfmt not installed" >&2
+    exit 2
+fi
+
+shopt -s nullglob globstar
+
+targets=()
+[[ -f install.sh ]] && targets+=(install.sh)
+targets+=(lib/*.sh)
+targets+=(scripts/**/*.sh)
+targets+=(tests/integration/*.sh)
+targets+=(tests/helpers/*.sh)
+
+for f in run_onchange_*; do
+    [[ -f "$f" ]] || continue
+    case "$f" in
+        *.tmpl) ;; # chezmoi-rendered; shfmt can't parse the template.
+        *) targets+=("$f") ;;
+    esac
+done
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "shfmt: no files to check"
+    exit 0
+fi
+
+fail=0
+for f in "${targets[@]}"; do
+    [[ -f "$f" ]] || continue
+    # shfmt prints the diff to stdout. Capture; fail if non-empty.
+    if ! diff_out="$(shfmt --diff -i 4 -ci "$f" 2>&1)"; then
+        printf 'FAIL (shfmt error): %s\n%s\n' "$f" "$diff_out" >&2
+        fail=1
+        continue
+    fi
+    if [[ -n "$diff_out" ]]; then
+        printf 'FAIL (format drift): %s\n%s\n' "$f" "$diff_out" >&2
+        fail=1
+    fi
+done
+exit "$fail"


### PR DESCRIPTION
## Summary

Story S3.10: introduces the repo-wide integration test tier. Four scripts under `tests/integration/` — shellcheck (IT-01), shfmt (IT-02), chezmoi-render (IT-03), and header-comments (IT-09) — plus a `make test-integration` aggregator and a distinct `test-integration` CI job. Also reformats 12 pre-existing scripts with `shfmt -i 4 -ci` to pass IT-02 (mechanical whitespace-only changes).

## Changes

- `tests/integration/shellcheck.sh` (IT-01) — shellcheck every `*.sh` under `install.sh`, `lib/`, `scripts/`, `tests/integration/`, `tests/helpers/`, plus `run_onchange_*` (non-`.tmpl`).
- `tests/integration/shfmt.sh` (IT-02) — shfmt `-i 4 -ci --diff` over the same target set; non-empty diff = failure.
- `tests/integration/chezmoi-render.sh` (IT-03) — `chezmoi execute-template` against every `*.tmpl` with a deterministic mock `rbw` shim on `$PATH` so CI never needs Vaultwarden.
- `tests/integration/header-comments.sh` (IT-09) — every `run_onchange_*` must start with a shebang (or `{{`-template preamble) + a comment naming its filename + ≥1 intent description (R-44).
- `Makefile` — new `test-integration` target runs all four in order; `help` updated.
- `.github/workflows/ci.yml` — new `test-integration` job invoking `install-lint-deps.sh` + `install-chezmoi.sh` + `run-integration.sh`. Three `run:` lines, each ≤5 lines (project rule).
- `scripts/ci/run-integration.sh` — thin delegator: `make test-integration`.
- 12 pre-existing scripts — mechanical `shfmt -i 4 -ci` reformats (case-arm spacing, pipe-at-end-of-line, redirect spacing) to pass IT-02. No semantic changes.

## Linked Issues

Closes #27

## Test Plan

- [x] `make lint` — clean (shellcheck 17 files)
- [x] `make test-unit` — 216/216 passing
- [x] `make test-integration` — all 4 pass locally (shellcheck 27 files, shfmt 27 files, chezmoi-render on every `*.tmpl`, header-comments on every `run_onchange_*`)
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- [x] Code review via `feature-dev:code-reviewer` — 0 CRITICAL/HIGH, 2 MEDIUM deferred (mock-shim catchall hardening, intent-counter coupling)
- [x] CI `test-integration` job verified green on push