### PR TITLE
fix(install): use upstream installers for chezmoi, direnv, rbw

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,17 @@ set -euo pipefail
 
 readonly BEGET_REPO_URL="https://github.com/bakeb7j0/beget"
 readonly REQUIRED_TOOLS=(curl git bash)
-# Always-install prereqs. pinentry-gnome3 added conditionally below.
-readonly BASE_PREREQS=(chezmoi rbw direnv pinentry-curses git curl)
+# Distro-managed prereqs — routed through apt/dnf via pkg_install.
+# pinentry-gnome3 is appended conditionally when running under GNOME.
+# direnv is intentionally NOT here: it's in Ubuntu's apt repos but not
+# in Rocky 9 (base or EPEL), so the upstream installer is the only
+# uniform path across both distros.
+readonly DISTRO_PREREQS=(pinentry-curses git curl)
+# Upstream prereqs — none of chezmoi, direnv, or rbw is uniformly
+# available in Ubuntu/Rocky default repos, so each has a dedicated
+# installer in lib/platform.sh (install_chezmoi, install_direnv,
+# install_rbw).
+readonly UPSTREAM_PREREQS=(chezmoi direnv rbw)
 
 # ---- Helpers -----------------------------------------------------------------
 
@@ -142,7 +151,7 @@ preflight() {
 # ---- Prereq install ----------------------------------------------------------
 
 install_prereqs() {
-    local pkgs=("${BASE_PREREQS[@]}")
+    local pkgs=("${DISTRO_PREREQS[@]}")
 
     # pinentry-gnome3 is only meaningful on GNOME desktops.
     if is_gnome; then
@@ -150,12 +159,21 @@ install_prereqs() {
     fi
 
     if [[ "$DRY_RUN" -eq 1 ]]; then
+        log "[dry-run] would ensure EPEL on RHEL-family"
         log "[dry-run] would pkg_install: ${pkgs[*]}"
-        return 0
+        log "[dry-run] would install upstream prereqs: ${UPSTREAM_PREREQS[*]}"
+    else
+        # direnv (and some other userspace tooling) live in EPEL on
+        # Rocky/RHEL, so EPEL has to be enabled before pkg_install
+        # runs. Noop on Debian-family.
+        pkg_ensure_epel || die "EPEL enablement failed"
+        log "installing distro prereqs: ${pkgs[*]}"
+        pkg_install "${pkgs[@]}" || die "distro prereq install failed"
     fi
 
-    log "installing prereqs: ${pkgs[*]}"
-    pkg_install "${pkgs[@]}"
+    install_chezmoi || die "chezmoi install failed"
+    install_direnv || die "direnv install failed"
+    install_rbw || die "rbw install failed"
 }
 
 # ---- Chezmoi init + apply ----------------------------------------------------

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -12,11 +12,18 @@
 #                              — register an apt or yum repo
 #   is_gnome                   — return 0 if running under GNOME
 #   die_if_unsupported_os      — abort if OS is not Ubuntu 24.04 or Rocky 9
+#   install_chezmoi            — install chezmoi via upstream get.chezmoi.io
+#   install_direnv             — install direnv via upstream direnv.net
+#   install_rbw                — install rbw via cargo (builds toolchain if needed)
 #
 # Test seams (env-var overrides, default shown):
-#   OS_RELEASE_FILE  — /etc/os-release
-#   APT_SOURCES_DIR  — /etc/apt/sources.list.d
-#   YUM_REPOS_DIR    — /etc/yum.repos.d
+#   OS_RELEASE_FILE        — /etc/os-release
+#   APT_SOURCES_DIR        — /etc/apt/sources.list.d
+#   YUM_REPOS_DIR          — /etc/yum.repos.d
+#   BEGET_CHEZMOI_INSTALLER — https://get.chezmoi.io
+#   BEGET_DIRENV_INSTALLER  — https://direnv.net/install.sh
+#   BEGET_RUSTUP_INSTALLER  — https://sh.rustup.rs
+#   DRY_RUN                — when 1, install_chezmoi/install_direnv/install_rbw log intent only
 
 # Emit an error and exit non-zero. Used for clean aborts.
 die() {
@@ -51,6 +58,37 @@ source_os_release() {
     export OS_MAJOR_VERSION="$major"
 }
 
+# Refresh the package manager's metadata cache. Cheap on an up-to-date
+# system and essential on one with stale / empty lists (e.g. a minimal
+# container with /var/lib/apt/lists/ pruned, or a long-idle VM). Called
+# automatically by pkg_install on first invocation per process.
+_pkg_cache_refreshed=0
+pkg_cache_refresh() {
+    if [[ "$_pkg_cache_refreshed" -eq 1 ]]; then
+        return 0
+    fi
+
+    if [[ -z "${OS_ID:-}" ]]; then
+        source_os_release
+    fi
+
+    case "$OS_ID" in
+        ubuntu | debian)
+            sudo apt-get update -qq
+            ;;
+        rocky | rhel | centos | almalinux | fedora)
+            # dnf makecache is a noop when metadata is fresh; honor its
+            # own age heuristics rather than forcing a full refresh.
+            sudo dnf makecache -q
+            ;;
+        *)
+            die "pkg_cache_refresh: unsupported OS_ID: $OS_ID"
+            ;;
+    esac
+
+    _pkg_cache_refreshed=1
+}
+
 # Install one or more packages using the native package manager.
 # Dispatches based on OS_ID (populated by source_os_release).
 pkg_install() {
@@ -61,6 +99,8 @@ pkg_install() {
     if [[ -z "${OS_ID:-}" ]]; then
         source_os_release
     fi
+
+    pkg_cache_refresh
 
     case "$OS_ID" in
         ubuntu | debian)
@@ -129,6 +169,192 @@ is_gnome() {
         return 0
     fi
     return 1
+}
+
+log_platform() {
+    printf '[platform] %s\n' "$*"
+}
+
+# Prepend a directory to PATH if it's not already present. Idempotent.
+_prepend_path() {
+    local dir="$1"
+    case ":${PATH}:" in
+        *":${dir}:"*) return 0 ;;
+    esac
+    export PATH="${dir}:${PATH}"
+}
+
+# On RHEL-family systems, ensure the EPEL repository is enabled.
+# Several distro-layer prereqs (direnv most notably) live in EPEL rather
+# than base — a fresh Rocky/RHEL install has no `direnv` package until
+# EPEL is added. Noop on Debian-family. Honors DRY_RUN.
+pkg_ensure_epel() {
+    if [[ -z "${OS_ID:-}" ]]; then
+        source_os_release
+    fi
+
+    case "$OS_ID" in
+        rocky | rhel | centos | almalinux)
+            if rpm -q epel-release >/dev/null 2>&1; then
+                log_platform "epel-release already installed"
+            elif [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+                log_platform "[dry-run] would dnf install -y epel-release"
+                log_platform "[dry-run] would dnf config-manager --set-enabled crb"
+                return 0
+            else
+                log_platform "enabling EPEL repository via epel-release"
+                sudo dnf install -y epel-release
+            fi
+            # Most EPEL userspace packages (direnv among them) depend on
+            # CRB (CodeReady Builder; disabled by default on Rocky/RHEL).
+            log_platform "ensuring CRB repository is enabled"
+            sudo dnf config-manager --set-enabled crb
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# Install chezmoi via the upstream installer (user-local, no sudo).
+# Noop when chezmoi is already on PATH. Honors DRY_RUN.
+install_chezmoi() {
+    local bindir="${HOME}/.local/bin"
+
+    if command -v chezmoi >/dev/null 2>&1; then
+        log_platform "chezmoi already installed at $(command -v chezmoi)"
+        return 0
+    fi
+
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log_platform "[dry-run] would install chezmoi via get.chezmoi.io into ${bindir}"
+        return 0
+    fi
+
+    mkdir -p "$bindir"
+    local installer="${BEGET_CHEZMOI_INSTALLER:-https://get.chezmoi.io}"
+    log_platform "installing chezmoi from ${installer} into ${bindir}"
+    # Capture the installer script separately: a sourced library can't set
+    # -o pipefail, so curl|sh would silently swallow a curl failure.
+    local script
+    script=$(curl -fsSL "$installer") ||
+        die "install_chezmoi: failed to fetch installer: $installer"
+    printf '%s\n' "$script" | sh -s -- -b "$bindir"
+    _prepend_path "$bindir"
+}
+
+# Install direnv via the upstream direnv.net installer (user-local,
+# no sudo). direnv is in Debian/Ubuntu apt but NOT in Rocky/RHEL 9 repos
+# (neither base nor EPEL ship it), so the upstream binary is the only
+# uniform install path. Noop when direnv is already on PATH.
+install_direnv() {
+    local bindir="${HOME}/.local/bin"
+
+    if command -v direnv >/dev/null 2>&1; then
+        log_platform "direnv already installed at $(command -v direnv)"
+        return 0
+    fi
+
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log_platform "[dry-run] would install direnv via direnv.net into ${bindir}"
+        return 0
+    fi
+
+    mkdir -p "$bindir"
+    local installer="${BEGET_DIRENV_INSTALLER:-https://direnv.net/install.sh}"
+    log_platform "installing direnv from ${installer} into ${bindir}"
+    # Capture the installer script separately to surface curl failures
+    # (sourced libraries can't set -o pipefail).
+    local script
+    script=$(curl -fsSL "$installer") ||
+        die "install_direnv: failed to fetch installer: $installer"
+    # direnv's installer honors bin_path for relocation.
+    printf '%s\n' "$script" | bin_path="$bindir" bash
+    _prepend_path "$bindir"
+}
+
+# Ensure a Rust toolchain meeting rbw's MSRV is available via rustup.
+# rbw 1.15 requires rustc 1.82+, which exceeds both Ubuntu 24.04 (1.75)
+# and Rocky 9's distro cargo, so we bootstrap rustup to ~/.cargo/bin
+# when the existing cargo is missing or too old. rustup is the Rust
+# community's canonical installer and keeps the toolchain user-local
+# (no sudo required).
+ensure_rust_toolchain() {
+    local cargo_bindir="${HOME}/.cargo/bin"
+    _prepend_path "$cargo_bindir"
+
+    if command -v cargo >/dev/null 2>&1 && command -v rustc >/dev/null 2>&1; then
+        # Check rustc is at least 1.82. `rustc --version` → "rustc X.Y.Z (...)"
+        local rustc_ver
+        rustc_ver=$(rustc --version | awk '{print $2}')
+        local major minor
+        major="${rustc_ver%%.*}"
+        minor="${rustc_ver#*.}"
+        minor="${minor%%.*}"
+        if [[ "$major" -gt 1 || ("$major" -eq 1 && "$minor" -ge 82) ]]; then
+            log_platform "rust toolchain ${rustc_ver} meets rbw MSRV (1.82)"
+            return 0
+        fi
+        log_platform "rust toolchain ${rustc_ver} below rbw MSRV (1.82) — bootstrapping via rustup"
+    else
+        log_platform "no cargo on PATH — bootstrapping rust via rustup"
+    fi
+
+    local installer="${BEGET_RUSTUP_INSTALLER:-https://sh.rustup.rs}"
+    # Capture the installer script separately to surface curl failures
+    # (sourced libraries can't set -o pipefail).
+    local script
+    script=$(curl --proto '=https' --tlsv1.2 -fsSL "$installer") ||
+        die "ensure_rust_toolchain: failed to fetch rustup installer: $installer"
+    printf '%s\n' "$script" | sh -s -- -y --default-toolchain stable --profile minimal
+    _prepend_path "$cargo_bindir"
+}
+
+# Install rbw via cargo. Noop when rbw is already on PATH. Honors DRY_RUN.
+# Installs native build deps (pkg-config, openssl dev headers, C compiler)
+# via pkg_install, then ensures a modern Rust toolchain through rustup
+# (distro cargo on Ubuntu 24.04 / Rocky 9 is too old — see
+# ensure_rust_toolchain), and finally invokes `cargo install rbw --locked`.
+install_rbw() {
+    local cargo_bindir="${HOME}/.cargo/bin"
+
+    if command -v rbw >/dev/null 2>&1; then
+        log_platform "rbw already installed at $(command -v rbw)"
+        return 0
+    fi
+
+    if [[ -z "${OS_ID:-}" ]]; then
+        source_os_release
+    fi
+
+    local -a build_deps
+    case "$OS_ID" in
+        ubuntu | debian)
+            build_deps=(pkg-config libssl-dev build-essential)
+            ;;
+        rocky | rhel | centos | almalinux | fedora)
+            build_deps=(pkg-config openssl-devel gcc)
+            ;;
+        *)
+            die "install_rbw: unsupported OS_ID: $OS_ID"
+            ;;
+    esac
+
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log_platform "[dry-run] would pkg_install rbw build deps: ${build_deps[*]}"
+        log_platform "[dry-run] would ensure rust toolchain via rustup"
+        log_platform "[dry-run] would cargo install rbw --locked into ${cargo_bindir}"
+        return 0
+    fi
+
+    log_platform "installing rbw build deps: ${build_deps[*]}"
+    pkg_install "${build_deps[@]}"
+
+    ensure_rust_toolchain
+
+    log_platform "cargo install rbw --locked (this can take 5-10 minutes)"
+    cargo install rbw --locked
+    _prepend_path "$cargo_bindir"
 }
 
 # Abort with a clear message unless the detected OS is in the supported set.

--- a/tests/e2e/e2e-01-fresh-ubuntu-minimal.sh
+++ b/tests/e2e/e2e-01-fresh-ubuntu-minimal.sh
@@ -28,11 +28,16 @@ run_test() {
     assert_eq "$OS_ID" "ubuntu" "os_id" || return 1
     assert_eq "$OS_MAJOR_VERSION" "24" "os_major" || return 1
 
-    # install_prereqs in dry-run mode must emit a pkg list but not
-    # actually invoke apt.
+    # install_prereqs in dry-run mode must emit both a distro pkg list
+    # and an upstream-installer marker but not actually invoke apt or
+    # cargo. The two-phase split is what fixes R-01 (chezmoi/rbw were
+    # never in the distro repos).
     local out
     out="$(install_prereqs 2>&1)" || return 1
-    assert_match "$out" "would pkg_install" "install_prereqs dry-run marker" || return 1
+    assert_match "$out" "would pkg_install" "distro dry-run marker" || return 1
+    assert_match "$out" "upstream prereqs" "upstream dry-run marker" || return 1
+    assert_match "$out" "chezmoi" "chezmoi mentioned" || return 1
+    assert_match "$out" "rbw" "rbw mentioned" || return 1
 }
 
 start=$(date +%s)

--- a/tests/unit/direnv.bats
+++ b/tests/unit/direnv.bats
@@ -78,8 +78,11 @@ EOF
 
 # ---- install.sh prereq list -------------------------------------------------
 
-@test "install.sh BASE_PREREQS list contains direnv (R-01)" {
-    grep -qE '^readonly BASE_PREREQS=\(.*\bdirenv\b.*\)' "$INSTALL_SH"
+@test "install.sh UPSTREAM_PREREQS list contains direnv (R-01)" {
+    # direnv moved from DISTRO_PREREQS to UPSTREAM_PREREQS because
+    # Rocky 9 ships it in neither base nor EPEL repos, so the upstream
+    # direnv.net installer is the only uniform cross-distro path.
+    grep -qE '^readonly UPSTREAM_PREREQS=\(.*\bdirenv\b.*\)' "$INSTALL_SH"
 }
 
 # ---- .envrc example quality -------------------------------------------------

--- a/tests/unit/install.bats
+++ b/tests/unit/install.bats
@@ -80,3 +80,51 @@ source_install() {
     run shellcheck "$INSTALL_SH"
     [ "$status" -eq 0 ]
 }
+
+@test "install.sh: install_prereqs dry-run emits distro and upstream markers" {
+    source_install
+    parse_flags --dry-run --role=minimal --skip-secrets
+    # Source the library so install_prereqs can resolve install_chezmoi /
+    # install_rbw / is_gnome. The OS dispatch never executes because
+    # DRY_RUN=1, but OS_ID is still needed for install_rbw's guard.
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/lib/platform.sh"
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+
+    run install_prereqs
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would pkg_install"* ]]
+    [[ "$output" == *"upstream prereqs"* ]]
+    [[ "$output" == *"chezmoi"* ]]
+    [[ "$output" == *"rbw"* ]]
+}
+
+@test "install.sh: install_prereqs dry-run never invokes real curl or cargo" {
+    source_install
+    parse_flags --dry-run --role=minimal --skip-secrets
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/lib/platform.sh"
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+
+    # Stub curl/cargo/sh/pkg_install to fail loudly if the dry-run branch
+    # accidentally invokes them. command -v chezmoi / rbw will already
+    # return true in the sourced test environment, so we also wipe those
+    # via a restricted PATH to force the [dry-run] branch.
+    curl() { printf 'FAIL: curl called\n' >&2; return 99; }
+    cargo() { printf 'FAIL: cargo called\n' >&2; return 99; }
+    pkg_install() { printf 'FAIL: pkg_install called\n' >&2; return 99; }
+    export -f curl cargo pkg_install
+
+    # Sandbox PATH so chezmoi / rbw are NOT found — forces the install
+    # branch inside install_chezmoi / install_rbw, which should still
+    # short-circuit on DRY_RUN=1.
+    PATH="/nonexistent" run install_prereqs
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"FAIL: curl called"* ]]
+    [[ "$output" != *"FAIL: cargo called"* ]]
+    [[ "$output" != *"FAIL: pkg_install called"* ]]
+}

--- a/tests/unit/platform.bats
+++ b/tests/unit/platform.bats
@@ -193,6 +193,307 @@ EOF
     [ ! -f "$APT_SOURCES_DIR/example.list" ]
 }
 
+@test "pkg_ensure_epel: noop on Ubuntu" {
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+    # Fail loudly if any package-manager command is called.
+    rpm() { printf 'FAIL: rpm called\n'; return 99; }
+    sudo() { printf 'FAIL: sudo called\n'; return 99; }
+    export -f rpm sudo
+    run pkg_ensure_epel
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"FAIL"* ]]
+}
+
+@test "pkg_ensure_epel: skips epel install but still enables CRB when present" {
+    make_os_release "rocky" "9.3"
+    source_os_release
+    rpm() { return 0; }   # simulate epel-release already installed
+    # Track what sudo gets called with; don't fail.
+    local calls="$BATS_TEST_TMPDIR/sudo-calls"
+    : >"$calls"
+    sudo() { printf '%s\n' "$*" >>"$calls"; return 0; }
+    export -f rpm sudo
+    run pkg_ensure_epel
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed"* ]]
+    # epel-release install must NOT have been invoked; CRB enablement MUST have.
+    run cat "$calls"
+    [[ "$output" != *"install -y epel-release"* ]]
+    [[ "$output" == *"config-manager --set-enabled crb"* ]]
+}
+
+@test "pkg_ensure_epel: installs epel-release AND enables CRB when absent" {
+    make_os_release "rocky" "9.3"
+    source_os_release
+    rpm() { return 1; }   # simulate epel-release NOT installed
+    local calls="$BATS_TEST_TMPDIR/sudo-calls"
+    : >"$calls"
+    sudo() { printf '%s\n' "$*" >>"$calls"; return 0; }
+    export -f rpm sudo
+    run pkg_ensure_epel
+    [ "$status" -eq 0 ]
+    run cat "$calls"
+    [[ "$output" == *"install -y epel-release"* ]]
+    [[ "$output" == *"config-manager --set-enabled crb"* ]]
+}
+
+@test "pkg_ensure_epel: dry-run on Rocky logs intent without dnf" {
+    make_os_release "rocky" "9.3"
+    source_os_release
+    export DRY_RUN=1
+    rpm() { return 1; }   # simulate "not installed"
+    sudo() { printf 'FAIL: sudo called\n'; return 99; }
+    export -f rpm sudo
+    run pkg_ensure_epel
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[dry-run]"* ]]
+    [[ "$output" == *"epel-release"* ]]
+    [[ "$output" == *"crb"* ]]
+    [[ "$output" != *"FAIL"* ]]
+    unset DRY_RUN
+}
+
+@test "install_chezmoi: noop when binary already on PATH" {
+    # A stub `chezmoi` on PATH should short-circuit the helper.
+    local shimdir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$shimdir"
+    cat >"$shimdir/chezmoi" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$shimdir/chezmoi"
+    PATH="$shimdir:$PATH"
+
+    # Fail loudly if curl is invoked — it must not be.
+    curl() { printf 'FAIL: curl called\n'; return 99; }
+    export -f curl
+
+    run install_chezmoi
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed"* ]]
+    [[ "$output" != *"FAIL"* ]]
+}
+
+@test "install_chezmoi: dry-run logs intent without invoking curl" {
+    # Sandbox PATH so chezmoi is NOT found, forcing the install branch,
+    # but keep a reference to the real PATH so bats teardown can still
+    # find `rm` and friends after `run`.
+    local saved_path="$PATH"
+    PATH="/nonexistent"
+    export DRY_RUN=1
+
+    curl() { printf 'FAIL: curl called\n'; return 99; }
+    export -f curl
+
+    run install_chezmoi
+    PATH="$saved_path"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[dry-run]"* ]]
+    [[ "$output" == *"get.chezmoi.io"* ]]
+    [[ "$output" != *"FAIL"* ]]
+    unset DRY_RUN
+}
+
+@test "install_chezmoi: aborts when installer fetch fails (R-07)" {
+    # Sourced libraries can't set -o pipefail, so a bare `curl | sh` pipe
+    # would mask curl failures. Verify the two-step capture pattern surfaces
+    # the failure as a non-zero exit plus a clear error message.
+    local saved_path="$PATH"
+    PATH="/nonexistent"
+
+    curl() { return 22; }
+    export -f curl
+
+    run install_chezmoi
+    PATH="$saved_path"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"failed to fetch installer"* ]]
+}
+
+@test "install_direnv: noop when binary already on PATH" {
+    local shimdir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$shimdir"
+    cat >"$shimdir/direnv" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$shimdir/direnv"
+    PATH="$shimdir:$PATH"
+
+    curl() { printf 'FAIL: curl called\n'; return 99; }
+    export -f curl
+
+    run install_direnv
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed"* ]]
+    [[ "$output" != *"FAIL"* ]]
+}
+
+@test "install_direnv: dry-run logs intent without invoking curl" {
+    local saved_path="$PATH"
+    PATH="/nonexistent"
+    export DRY_RUN=1
+
+    curl() { printf 'FAIL: curl called\n'; return 99; }
+    export -f curl
+
+    run install_direnv
+    PATH="$saved_path"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[dry-run]"* ]]
+    [[ "$output" == *"direnv.net"* ]]
+    [[ "$output" != *"FAIL"* ]]
+    unset DRY_RUN
+}
+
+@test "install_direnv: aborts when installer fetch fails (R-07)" {
+    local saved_path="$PATH"
+    PATH="/nonexistent"
+
+    curl() { return 22; }
+    export -f curl
+
+    run install_direnv
+    PATH="$saved_path"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"failed to fetch installer"* ]]
+}
+
+@test "install_rbw: noop when binary already on PATH" {
+    local shimdir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$shimdir"
+    cat >"$shimdir/rbw" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$shimdir/rbw"
+    PATH="$shimdir:$PATH"
+
+    cargo() { printf 'FAIL: cargo called\n'; return 99; }
+    pkg_install() { printf 'FAIL: pkg_install called\n'; return 99; }
+    export -f cargo pkg_install
+
+    run install_rbw
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed"* ]]
+    [[ "$output" != *"FAIL"* ]]
+}
+
+@test "install_rbw: dry-run logs Ubuntu build deps without invoking cargo or curl" {
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+    local saved_path="$PATH"
+    PATH="/nonexistent"
+    export DRY_RUN=1
+
+    cargo() { printf 'FAIL: cargo called\n'; return 99; }
+    pkg_install() { printf 'FAIL: pkg_install called\n'; return 99; }
+    curl() { printf 'FAIL: curl called\n'; return 99; }
+    export -f cargo pkg_install curl
+
+    run install_rbw
+    PATH="$saved_path"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[dry-run]"* ]]
+    [[ "$output" == *"libssl-dev"* ]]
+    [[ "$output" == *"build-essential"* ]]
+    [[ "$output" == *"rust toolchain via rustup"* ]]
+    [[ "$output" == *"cargo install rbw"* ]]
+    [[ "$output" != *"FAIL"* ]]
+    unset DRY_RUN
+}
+
+@test "install_rbw: dry-run logs Rocky build deps (dnf-flavored package names)" {
+    make_os_release "rocky" "9.3"
+    source_os_release
+    local saved_path="$PATH"
+    PATH="/nonexistent"
+    export DRY_RUN=1
+
+    cargo() { printf 'FAIL: cargo called\n'; return 99; }
+    pkg_install() { printf 'FAIL: pkg_install called\n'; return 99; }
+    curl() { printf 'FAIL: curl called\n'; return 99; }
+    export -f cargo pkg_install curl
+
+    run install_rbw
+    PATH="$saved_path"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"openssl-devel"* ]]
+    [[ "$output" == *"gcc"* ]]
+    # Ubuntu-specific packages must NOT appear on Rocky.
+    [[ "$output" != *"libssl-dev"* ]]
+    [[ "$output" != *"build-essential"* ]]
+    unset DRY_RUN
+}
+
+@test "ensure_rust_toolchain: noop when rustc ≥ 1.82 already on PATH" {
+    local shimdir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$shimdir"
+    cat >"$shimdir/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    cat >"$shimdir/rustc" <<'EOF'
+#!/usr/bin/env bash
+echo "rustc 1.85.0 (abc 2025-01-01)"
+EOF
+    chmod +x "$shimdir/cargo" "$shimdir/rustc"
+    PATH="$shimdir:$PATH"
+
+    curl() { printf 'FAIL: curl called\n'; return 99; }
+    export -f curl
+
+    run ensure_rust_toolchain
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"meets rbw MSRV"* ]]
+    [[ "$output" != *"FAIL"* ]]
+}
+
+@test "ensure_rust_toolchain: triggers rustup when rustc too old" {
+    local shimdir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$shimdir"
+    cat >"$shimdir/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    cat >"$shimdir/rustc" <<'EOF'
+#!/usr/bin/env bash
+echo "rustc 1.75.0 (abc 2024-01-01)"
+EOF
+    chmod +x "$shimdir/cargo" "$shimdir/rustc"
+    PATH="$shimdir:$PATH"
+
+    # Capture the rustup-pipe with stub curl | sh. The function pipes
+    # curl output to sh, so replacing both at once is the cleanest seam.
+    local marker="$BATS_TEST_TMPDIR/rustup-invoked"
+    curl() { printf '#!/bin/sh\ntouch %s\n' "$marker"; }
+    sh() { cat | bash "$@"; }
+    export -f curl sh
+
+    run ensure_rust_toolchain
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"below rbw MSRV"* ]]
+    [[ "$output" == *"bootstrapping via rustup"* ]]
+    [ -f "$marker" ]
+}
+
+@test "ensure_rust_toolchain: aborts when rustup fetch fails (R-07)" {
+    # Force the rustup-bootstrap branch: no cargo/rustc on PATH, curl
+    # fails to download the installer. The function must fail loudly
+    # rather than silently proceeding.
+    local saved_path="$PATH"
+    PATH="/nonexistent"
+
+    curl() { return 22; }
+    export -f curl
+
+    run ensure_rust_toolchain
+    PATH="$saved_path"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"failed to fetch rustup installer"* ]]
+}
+
 @test "pkg_repo_add: Rocky writes .repo under YUM_REPOS_DIR" {
     make_os_release "rocky" "9.3"
     source_os_release


### PR DESCRIPTION
## Summary

On Ubuntu 24.04 and Rocky 9, three of the bootstrap prereqs — **chezmoi**, **rbw**, and (on Rocky) **direnv** — are not available in distro default repos, which caused the `curl | bash` one-liner to fail with `E: Unable to locate package chezmoi/rbw` on fresh containers. This PR splits prereq installation into two tiers and delegates the three outliers to dedicated upstream helpers.

## Changes

**`install.sh`**
- Replaced `BASE_PREREQS` with `DISTRO_PREREQS=(pinentry-curses git curl)` and `UPSTREAM_PREREQS=(chezmoi direnv rbw)`.
- Refactored `install_prereqs()` into two phases with explicit `|| die` checks (silent failures were cascading through the sourced context) and EPEL enablement before `pkg_install`.

**`lib/platform.sh`** (+218 lines)
- `install_chezmoi` — `get.chezmoi.io` → `~/.local/bin` (idempotent, honors `DRY_RUN` and `BEGET_CHEZMOI_INSTALLER`).
- `install_direnv` — `direnv.net/install.sh` → `~/.local/bin` (relocated via `bin_path` seam; direnv is absent from Rocky 9 base + EPEL + CRB).
- `install_rbw` — installs native build deps via `pkg_install`, then `ensure_rust_toolchain`, then `cargo install rbw --locked`.
- `ensure_rust_toolchain` — bootstraps rustup when rustc < 1.82 (rbw 1.15 MSRV). Distro cargo is 1.75 on both supported distros.
- `pkg_cache_refresh` — auto-invoked from `pkg_install` once per process; guards against the Dockerfile's empty `/var/lib/apt/lists/*` and long-idle production hosts.
- `pkg_ensure_epel` — Rocky/RHEL: installs `epel-release` and enables CRB (direnv needs EPEL; EPEL needs CRB).
- All `curl`-piped installers use the **capture-then-pipe** pattern (precedent: `pkg_repo_add` at line 142) so fetch failures surface via `die` rather than being silently swallowed by the pipe — sourced libs can't set `-o pipefail`.

## Test Plan

- [x] `make lint` — shellcheck clean on `install.sh`, `lib/platform.sh`, and all `run_onchange_*`.
- [x] `make test-quick` — **234 unit tests pass** (was 231; +3 failure-path tests for `install_chezmoi`, `install_direnv`, `ensure_rust_toolchain` when curl fails). Integration tier clean: shellcheck, shfmt (`-i 4 -ci`), chezmoi-render, header-comments, make-targets.
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` — zero findings.
- [x] **Empirical container verification** — `bash install.sh --skip-secrets` inside fresh `beget-e2e:ubuntu24`: chezmoi 2.70.2 → `~/.local/bin/chezmoi`, direnv 2.37.1 → `~/.local/bin/direnv`, rbw 1.15.0 → `~/.cargo/bin/rbw`. All resolvable on `$PATH`.
- [x] Same verification on `beget-e2e:rocky9` — same three tools resolvable at the same paths.
- [x] Idempotent re-run on both containers: all three helpers short-circuit on "already installed."

## Linked Issues

Closes #86