### PR TITLE
test(e2e): curl|bash one-liner on Rocky 9 + pinentry name helper

### DIFF
--- a/docs/beget-vrtm.md
+++ b/docs/beget-vrtm.md
@@ -36,8 +36,8 @@ untraced rows.
 
 | Req ID | Summary | Category | Verifying Test IDs | Section 4 Flow | Notes |
 |---|---|---|---|---|---|
-| R-01 | `curl ... \| bash` bootstrap installs prereqs (chezmoi, rbw, direnv, pinentries, git, curl) | Bootstrap | E2E-01, E2E-09, IT-08, MV-01, `tests/unit/direnv.bats` (BASE_PREREQS) | §4.2 | E2E-09 exercises the real `curl \| bash` path end-to-end against live apt via loopback HTTP server |
-| R-02 | Abort when OS is not Ubuntu 24.04+ or RHEL 9+/family | Bootstrap | IT-01, `tests/unit/os-detection.bats` (`die_if_unsupported_os`) | §4.2 | 5 mocked-os-release unit tests cover Rocky 10, Ubuntu 26, Fedora, CentOS, AlmaLinux |
+| R-01 | `curl ... \| bash` bootstrap installs prereqs (chezmoi, rbw, direnv, pinentries, git, curl) | Bootstrap | E2E-01, E2E-09, E2E-10, IT-08, MV-01, `tests/unit/direnv.bats` (BASE_PREREQS) | §4.2 | E2E-09 (Ubuntu) and E2E-10 (Rocky) exercise the real `curl \| bash` path end-to-end against live apt/dnf via loopback HTTP server; `tests/unit/platform.bats` (`pkg_name_pinentry_tty`) covers the Rocky vs Debian pinentry-name divergence |
+| R-02 | Abort when OS is not Ubuntu 24.04+ or RHEL 9+/family | Bootstrap | IT-01, `tests/unit/os-detection.bats` (`die_if_unsupported_os`), E2E-09, E2E-10 | §4.2 | 5 mocked-os-release unit tests cover Rocky 10, Ubuntu 26, Fedora, CentOS, AlmaLinux; E2E-09/10 confirm the bootstrap does NOT abort on the two supported families |
 | R-03 | Abort if invoked as root without `--allow-root` | Bootstrap | E2E-08, `tests/unit/install.bats` (preflight root tests) | §4.2 | Override path also covered (`--allow-root` accepted) |
 | R-04 | `--dry-run` prints actions without executing | Bootstrap | `tests/unit/install.bats` (parse_flags sets DRY_RUN), IT-08 | §4.2 | `chezmoi apply --dry-run` wired via `make apply-dry` |
 | R-05 | `--role=<workstation\|server\|minimal>` passed to `chezmoi init --data` | Bootstrap | `tests/unit/install.bats` (parse_flags sets ROLE), E2E-01 (minimal), E2E-02 (workstation), E2E-03 (workstation/Rocky) | §4.2 | |
@@ -89,7 +89,7 @@ untraced rows.
 
 - Unit tests (bats): cover R-02, R-03, R-04, R-05, R-06, R-13, R-14, R-15, R-16, R-24, R-25, R-26, R-27, R-28, R-29, R-31, R-32, R-33, R-34, R-35, R-36, R-37, R-38, R-39, R-40, R-41, R-43
 - Integration tests: cover R-01, R-07, R-09, R-10, R-11, R-12, R-17, R-18, R-31, R-32, R-33, R-34, R-35, R-36, R-37, R-38, R-40, R-41, R-42, R-44
-- E2E tests: cover R-01, R-03, R-05, R-06, R-07, R-08, R-11, R-12, R-17, R-18, R-19, R-23, R-30, R-33, R-38, R-42
+- E2E tests: cover R-01, R-02, R-03, R-05, R-06, R-07, R-08, R-11, R-12, R-17, R-18, R-19, R-23, R-30, R-33, R-38, R-42
 - Manual verifications: cover R-01, R-13, R-16, R-19, R-20, R-21, R-22, R-24, R-25, R-27, R-29, R-30, R-36, R-39, R-43
 - Section 4 flows: every theme with user-visible behavior maps to §4.2–§4.7
 - Structural inspection only: R-45 (README contents) and R-46 (CHANGELOG presence) — reviewed at /dod

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -38,11 +38,14 @@ new issue labeled `type::bug`.
 ### MV-01 — First-time bootstrap on a fresh VM
 
 **Traces**: R-01, R-16. **Flow**: §4.2. **Runbook**: §1.
-**Automated coverage**: [E2E-09](../tests/e2e/e2e-09-oneliner-ubuntu.sh) exercises
-the same `curl … | bash` path on Ubuntu 24.04 end-to-end against live apt (serves
-install.sh over a loopback HTTP server to sidestep main-branch dependence). MV-01
-remains the canonical check for the desktop/GUI and real-Vaultwarden legs that
-E2E-09 deliberately skips (`--skip-secrets`, headless).
+**Automated coverage**: [E2E-09](../tests/e2e/e2e-09-oneliner-ubuntu.sh) (Ubuntu
+24.04) and [E2E-10](../tests/e2e/e2e-10-oneliner-rocky.sh) (Rocky 9) exercise the
+same `curl … | bash` path end-to-end against live apt/dnf (serve install.sh over a
+loopback HTTP server to sidestep main-branch dependence). E2E-10 also validates
+the Rocky-vs-Debian `pinentry` naming divergence handled by
+`lib/platform.sh:pkg_name_pinentry_tty`. MV-01 remains the canonical check for
+the desktop/GUI and real-Vaultwarden legs that both E2E tests deliberately skip
+(`--skip-secrets`, headless).
 
 **Preconditions**
 - Fresh VM (Ubuntu 24.04 or Rocky 9) with network and a non-root user.

--- a/install.sh
+++ b/install.sh
@@ -30,11 +30,14 @@ readonly BEGET_REPO_URL="https://github.com/bakeb7j0/beget"
 readonly BEGET_RAW_BASE="${BEGET_RAW_BASE:-}"
 readonly REQUIRED_TOOLS=(curl git bash)
 # Distro-managed prereqs — routed through apt/dnf via pkg_install.
-# pinentry-gnome3 is appended conditionally when running under GNOME.
+# The curses/TTY pinentry is resolved per-distro by
+# pkg_name_pinentry_tty() (Ubuntu: pinentry-curses, Rocky: pinentry)
+# so we build the list dynamically in install_prereqs rather than
+# baking a Debian-centric constant. pinentry-gnome3 is appended
+# conditionally when running under GNOME.
 # direnv is intentionally NOT here: it's in Ubuntu's apt repos but not
 # in Rocky 9 (base or EPEL), so the upstream installer is the only
 # uniform path across both distros.
-readonly DISTRO_PREREQS=(pinentry-curses git curl)
 # Upstream prereqs — none of chezmoi, direnv, or rbw is uniformly
 # available in Ubuntu/Rocky default repos, so each has a dedicated
 # installer in lib/platform.sh (install_chezmoi, install_direnv,
@@ -171,7 +174,11 @@ preflight() {
 # ---- Prereq install ----------------------------------------------------------
 
 install_prereqs() {
-    local pkgs=("${DISTRO_PREREQS[@]}")
+    # Build the distro-prereq list now that OS_ID is known (preflight
+    # has already sourced /etc/os-release). pkg_name_pinentry_tty()
+    # lives in lib/platform.sh and resolves the curses-pinentry name
+    # per-distro.
+    local pkgs=("$(pkg_name_pinentry_tty)" git curl)
 
     # pinentry-gnome3 is only meaningful on GNOME desktops.
     if is_gnome; then

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -89,6 +89,22 @@ pkg_cache_refresh() {
     _pkg_cache_refreshed=1
 }
 
+# Resolve the distro-appropriate package name for the curses/TTY
+# pinentry. Debian/Ubuntu ship it as `pinentry-curses`; RHEL-family
+# dnf repos ship it as plain `pinentry` (no `-curses` suffix because
+# that's the only pinentry variant in the base repos). Callers emit
+# the returned name straight into pkg_install.
+pkg_name_pinentry_tty() {
+    if [[ -z "${OS_ID:-}" ]]; then
+        source_os_release
+    fi
+    case "$OS_ID" in
+        ubuntu | debian) printf 'pinentry-curses' ;;
+        rocky | rhel | centos | almalinux | fedora) printf 'pinentry' ;;
+        *) die "pkg_name_pinentry_tty: unsupported OS_ID: $OS_ID" ;;
+    esac
+}
+
 # Install one or more packages using the native package manager.
 # Dispatches based on OS_ID (populated by source_os_release).
 pkg_install() {

--- a/tests/e2e/Dockerfile.rocky9
+++ b/tests/e2e/Dockerfile.rocky9
@@ -17,6 +17,7 @@ RUN dnf install --allowerasing -yq \
         curl \
         git \
         jq \
+        python3 \
         sudo \
         tzdata
 

--- a/tests/e2e/e2e-10-oneliner-rocky.sh
+++ b/tests/e2e/e2e-10-oneliner-rocky.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-10-oneliner-rocky.sh -- E2E-10.
+#
+# Requirement: R-02 -- the `curl -fsSL ... | bash` one-liner bootstrap
+# path works end-to-end on Rocky 9. RPM-family counterpart to E2E-09
+# (Ubuntu 24.04): same loopback-HTTP + BEGET_RAW_BASE strategy, same
+# --skip-apply narrowing, different package manager and different
+# distro-specific package names (notably `pinentry` vs
+# `pinentry-curses` — the lib/platform.sh::pkg_name_pinentry_tty
+# helper is what makes this test pass where a Debian-hardcoded
+# constant would fail).
+#
+# Serving the repo's current working-tree over a loopback Python
+# http.server and pointing BEGET_RAW_BASE at it keeps the test
+# pre-merge-hermetic: we exercise the install.sh / lib/platform.sh
+# under review, not whatever is at HEAD on GitHub.
+#
+# The Rocky image pre-installs chezmoi at /usr/local/bin; we
+# PATH-scrub rather than file-delete (see e2e-09 for rationale: the
+# CI runner maps to a host UID not in /etc/passwd, so sudo fails).
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+OWNER="bakeb7j0"
+REPO_NAME="beget"
+
+start_http_server() {
+    local root="$1"
+    local port_file="$2"
+    python3 - "$root" "$port_file" <<'PY' &
+import sys, os, socketserver
+from http.server import SimpleHTTPRequestHandler
+
+root = sys.argv[1]
+port_file = sys.argv[2]
+os.chdir(root)
+
+class Handler(SimpleHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+    port = httpd.server_address[1]
+    with open(port_file, "w") as fh:
+        fh.write(str(port))
+    httpd.serve_forever()
+PY
+    HTTP_PID=$!
+}
+
+wait_for_port() {
+    local port="$1" tries=0
+    while ((tries < 50)); do
+        if bash -c "exec 3<>/dev/tcp/127.0.0.1/$port" 2>/dev/null; then
+            exec 3<&- 3>&-
+            return 0
+        fi
+        tries=$((tries + 1))
+        sleep 0.1
+    done
+    return 1
+}
+
+# shellcheck disable=SC2317
+cleanup() {
+    if [[ -n "${HTTP_PID:-}" ]] && kill -0 "$HTTP_PID" 2>/dev/null; then
+        kill "$HTTP_PID" 2>/dev/null || true
+        wait "$HTTP_PID" 2>/dev/null || true
+    fi
+    [[ -n "${SERVE_ROOT:-}" && -d "$SERVE_ROOT" ]] && rm -rf "$SERVE_ROOT"
+    [[ -n "${PORT_FILE:-}" && -f "$PORT_FILE" ]] && rm -f "$PORT_FILE"
+    [[ -n "${INSTALL_LOG:-}" && -f "$INSTALL_LOG" ]] && rm -f "$INSTALL_LOG"
+}
+trap cleanup EXIT
+
+run_test() {
+    # Scrub pre-baked chezmoi out of PATH (see e2e-09 rationale).
+    # install_chezmoi / install_direnv install to $HOME/.local/bin;
+    # install_rbw uses `cargo install` which lands in
+    # $HOME/.cargo/bin. Both dirs are prepended so post-condition
+    # `command -v` checks see freshly-installed binaries.
+    export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/usr/bin:/bin"
+    hash -r
+    if command -v chezmoi >/dev/null 2>&1; then
+        _assert_fail "chezmoi still on PATH after scrub: $(command -v chezmoi)"
+        return 1
+    fi
+
+    SERVE_ROOT="$(mktemp -d)"
+    mkdir -p "$SERVE_ROOT/$OWNER/$REPO_NAME/raw"
+    ln -s "$REPO" "$SERVE_ROOT/$OWNER/$REPO_NAME/raw/HEAD"
+
+    PORT_FILE="$(mktemp)"
+    start_http_server "$SERVE_ROOT" "$PORT_FILE"
+
+    local tries=0 port=""
+    while ((tries < 50)); do
+        if [[ -s "$PORT_FILE" ]]; then
+            port="$(cat "$PORT_FILE")"
+            break
+        fi
+        tries=$((tries + 1))
+        sleep 0.1
+    done
+    if [[ -z "$port" ]]; then
+        _assert_fail "http server did not report a port within 5s"
+        return 1
+    fi
+    if ! wait_for_port "$port"; then
+        _assert_fail "http server bound port $port but did not accept connections"
+        return 1
+    fi
+
+    local raw_base="http://localhost:${port}/${OWNER}/${REPO_NAME}/raw/HEAD"
+
+    if ! curl -fsSL "${raw_base}/install.sh" -o /dev/null; then
+        _assert_fail "loopback server did not serve install.sh at ${raw_base}/install.sh"
+        return 1
+    fi
+
+    # `export` matters: `VAR=val cmd1 | cmd2` scopes the assignment
+    # to cmd1 only, so the piped bash subprocess would see an empty
+    # BEGET_RAW_BASE and fall back to the real GitHub raw URL --
+    # silently defeating the whole loopback-server premise.
+    INSTALL_LOG="$(mktemp)"
+    export BEGET_RAW_BASE="$raw_base"
+    if ! curl -fsSL "${raw_base}/install.sh" |
+        bash -s -- --skip-secrets --skip-apply --role=minimal >"$INSTALL_LOG" 2>&1; then
+        echo "--- install.sh output ---" >&2
+        cat "$INSTALL_LOG" >&2
+        _assert_fail "install.sh exited non-zero"
+        return 1
+    fi
+
+    hash -r
+
+    if ! command -v chezmoi >/dev/null 2>&1; then
+        _assert_fail "chezmoi not on PATH after install.sh"
+        return 1
+    fi
+    local cm_version
+    cm_version="$(chezmoi --version 2>&1 || true)"
+    if [[ -z "$cm_version" ]]; then
+        _assert_fail "chezmoi --version emitted empty output"
+        return 1
+    fi
+
+    if ! command -v rbw >/dev/null 2>&1; then
+        _assert_fail "rbw not on PATH after install.sh"
+        return 1
+    fi
+    # Pin rbw's install path to prove install_rbw exercised its cargo
+    # branch rather than some pre-baked system copy we missed. A future
+    # Dockerfile change that pre-installs rbw would otherwise make the
+    # `command -v rbw` check above silently vacuous.
+    if [[ "$(command -v rbw)" != "${HOME}/.cargo/bin/rbw" ]]; then
+        _assert_fail "rbw at unexpected path: $(command -v rbw) (expected ${HOME}/.cargo/bin/rbw)"
+        return 1
+    fi
+
+    if ! command -v direnv >/dev/null 2>&1; then
+        _assert_fail "direnv not on PATH after install.sh"
+        return 1
+    fi
+
+    # Rocky ships the curses pinentry as plain `pinentry` (no
+    # `-curses` suffix — it's the only pinentry variant in the base
+    # dnf repos). This is the distro-specific assertion that
+    # validates the pkg_name_pinentry_tty() helper: if install.sh
+    # tried to `dnf install pinentry-curses` on Rocky, the whole
+    # bootstrap would have failed before we got here.
+    if ! rpm -q pinentry >/dev/null 2>&1; then
+        _assert_fail "pinentry not installed via dnf"
+        return 1
+    fi
+
+    # chezmoi init must have materialized its source state.
+    if [[ ! -d "${HOME}/.local/share/chezmoi" ]]; then
+        _assert_fail "${HOME}/.local/share/chezmoi does not exist (chezmoi init did not run?)"
+        return 1
+    fi
+}
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-10 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-10 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/unit/platform.bats
+++ b/tests/unit/platform.bats
@@ -92,6 +92,46 @@ EOF
     [[ "$output" == *"unsupported OS_ID: arch"* ]]
 }
 
+@test "pkg_name_pinentry_tty: Ubuntu resolves to pinentry-curses" {
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+    run pkg_name_pinentry_tty
+    [ "$status" -eq 0 ]
+    [ "$output" = "pinentry-curses" ]
+}
+
+@test "pkg_name_pinentry_tty: Debian resolves to pinentry-curses" {
+    make_os_release "debian" "12"
+    source_os_release
+    run pkg_name_pinentry_tty
+    [ "$status" -eq 0 ]
+    [ "$output" = "pinentry-curses" ]
+}
+
+@test "pkg_name_pinentry_tty: Rocky resolves to plain pinentry" {
+    make_os_release "rocky" "9.3"
+    source_os_release
+    run pkg_name_pinentry_tty
+    [ "$status" -eq 0 ]
+    [ "$output" = "pinentry" ]
+}
+
+@test "pkg_name_pinentry_tty: Fedora resolves to plain pinentry" {
+    make_os_release "fedora" "39"
+    source_os_release
+    run pkg_name_pinentry_tty
+    [ "$status" -eq 0 ]
+    [ "$output" = "pinentry" ]
+}
+
+@test "pkg_name_pinentry_tty: unsupported OS aborts" {
+    make_os_release "arch" "rolling"
+    source_os_release
+    run pkg_name_pinentry_tty
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS_ID: arch"* ]]
+}
+
 @test "die_if_unsupported_os: Ubuntu 24.04 passes" {
     make_os_release "ubuntu" "24.04"
     run die_if_unsupported_os


### PR DESCRIPTION
## Summary

Adds `tests/e2e/e2e-10-oneliner-rocky.sh` as the RPM-family counterpart to E2E-09 (merged in #92). Also introduces `pkg_name_pinentry_tty()` in `lib/platform.sh` to resolve the curses-pinentry package name per-distro — Ubuntu ships it as `pinentry-curses`, Rocky's dnf repos ship it as plain `pinentry` (the only pinentry variant in the base repos). Previously `install.sh` hardcoded `pinentry-curses` in a readonly array, which would have broken `dnf install` on Rocky.

## Changes

- `lib/platform.sh`: new `pkg_name_pinentry_tty()` helper with Ubuntu/Debian → `pinentry-curses`, RHEL-family → `pinentry`, and `die` on unsupported OS_ID.
- `install.sh`: removed the Debian-centric `readonly DISTRO_PREREQS=(pinentry-curses git curl)` constant; `install_prereqs` now builds `pkgs=("$(pkg_name_pinentry_tty)" git curl)` dynamically after `preflight` has populated OS_ID.
- `tests/e2e/e2e-10-oneliner-rocky.sh`: mirror of E2E-09 with Rocky-specific assertions — `rpm -q pinentry` (not `pinentry-curses`), PATH pinned to resolve the cargo-installed rbw at `~/.cargo/bin/rbw`, and the same loopback-HTTP + `BEGET_RAW_BASE` pattern for pre-merge hermeticity.
- `tests/e2e/Dockerfile.rocky9`: added `python3` (needed by the loopback `http.server`).
- `tests/unit/platform.bats`: 5 new bats cases — Ubuntu, Debian, Rocky, Fedora, unsupported-OS-aborts.
- `docs/beget-vrtm.md`: R-01 and R-02 both trace to E2E-10 now; coverage summary updated.
- `docs/manual-verification.md`: MV-01 cross-references both E2E-09 (Ubuntu) and E2E-10 (Rocky).

## Linked Issues

Closes #88

## Test Plan

- `./scripts/ci/run-unit.sh` — 239/239 pass (5 new `pkg_name_pinentry_tty` cases included).
- `./scripts/ci/run-lint.sh` — clean.
- `trivy fs --scanners vuln --severity HIGH,CRITICAL .` — 0 findings.
- `./scripts/ci/run-e2e.sh rocky9` — full E2E-10 run (dnf install + rustup bootstrap + `cargo install rbw --locked` + chezmoi init) will run in CI; the `-rocky` filename suffix routes it automatically to the Rocky distro job.
- `./scripts/ci/run-e2e.sh ubuntu24` — E2E-10 is skipped on Ubuntu (filename-based filter in `scripts/ci/run-e2e.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)