### PR TITLE
feat(install): make install.sh purely user-local; factor sudo ops to install-prereqs.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,49 @@ The Dev Spec covers:
 - Definition of Done
 - Phased implementation plan: 28 stories across 11 waves and 3 phases
 
-## One-liner install (Phase 1 target, not yet available)
+## Install
+
+The bootstrap is a two-step install: a one-time root step that lays down the
+distro packages beget's toolchain depends on, then a user-local step that does
+everything else.
+
+**Step 1 — distro prerequisites (one-time, runs as root):**
+
+```bash
+curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/scripts/install-prereqs.sh | sudo bash
+```
+
+This installs packages that can only come from the system package manager:
+`pinentry` (for GPG/rbw prompts), `pkg-config` and the OpenSSL dev headers +
+C toolchain (needed by `cargo install rbw`), plus the small set of userland
+tools (`git`, `curl`) beget itself shells out to. On Rocky 9 it also enables
+EPEL and CodeReady Builder. See [`scripts/install-prereqs.sh`](scripts/install-prereqs.sh)
+for the full per-distro package list.
+
+**Step 2 — user-local install (no sudo needed):**
 
 ```bash
 curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/install.sh | bash
 ```
 
-`install.sh` is produced by Phase 1. It does not exist yet.
+`install.sh` installs chezmoi, direnv, rbw, and everything else into
+`~/.local/bin` / `~/.cargo/bin`, clones this repo, and applies chezmoi. It
+scans for the step-1 prerequisites up front and exits with actionable guidance
+if anything is missing — it **never** calls `sudo` itself, which means the
+one-liner is safe to run non-interactively (CI, containers without passwordless
+sudo, etc.).
+
+CI and automation paths that know the host is already prepped can pass
+`--skip-prereqs` to bypass the up-front scan.
 
 ## Prerequisites
 
 _Stub — detailed prerequisites will be documented as stories land._
 
 - A supported Linux distribution (see [Supported Platforms](#supported-platforms))
-- `git`, `curl`, and `bash` available on the target host
+- `git`, `curl`, and `bash` available on the target host (`install-prereqs.sh`
+  provides `git` and `curl`; a minimal bootstrap needs `curl` + `bash` to
+  fetch step 1).
 - Network access to GitHub for fetching this repo and its dependencies
 
 ## Supported Platforms

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -37,30 +37,39 @@ change — pair each runbook section with the corresponding procedure in
 - Ubuntu 24.04+ or RHEL 9+/family (Fedora, Rocky, Alma).
 - Network access to `github.com` and the Vaultwarden host.
 - Vaultwarden master password memorized.
-- A user account with `sudo` (not root — installer refuses `--allow-root` by default).
+- A user account with `sudo` access (needed for step 1 only; `install.sh` itself is purely user-local).
 
 **Commands**
 
 ```bash
-# One-liner entry point:
+# Step 1: distro prerequisites (one-time, root). Installs pinentry, build
+# deps for rbw, EPEL+CRB on Rocky, etc. Safe to run repeatedly.
+curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/scripts/install-prereqs.sh | sudo bash
+
+# Step 2: user-local install (no sudo). Scans for the step-1 packages up
+# front; exits with remediation if anything is missing. If you've already
+# prepped the host (e.g. via a config-management tool), pass --skip-prereqs
+# to bypass the scan.
 curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/install.sh | bash -s -- --role=workstation
 ```
 
-Expected output (abridged):
+Expected output from step 2 (abridged):
 
 ```
-[install] beget bootstrap starting
-[install] OS: ubuntu 24.04 — supported
-[install] installing prerequisites: chezmoi rbw direnv pinentry-curses git curl
-...
-[install] running: chezmoi init https://github.com/bakeb7j0/beget --data role=workstation
-[install] chezmoi apply complete
-[install] done. Open a new terminal for all changes to take effect.
+[install] pre-flight OK: role=workstation os=ubuntu:24 dry_run=0 skip_secrets=0
+[install] distro prereqs OK: pinentry-curses git curl pkg-config libssl-dev build-essential
+[platform] installing chezmoi from https://get.chezmoi.io into /home/<you>/.local/bin
+[platform] installing direnv from https://direnv.net/install.sh into /home/<you>/.local/bin
+[platform] cargo install rbw --locked (this can take 5-10 minutes)
+[install] chezmoi init https://github.com/bakeb7j0/beget (role=workstation)
+[install] chezmoi apply ...
+[install] bootstrap complete — role=workstation
+[install] next: open a fresh shell and run 'chezmoi apply' again to pick up any follow-on changes.
 ```
 
 **Post-condition check** — run the [Deployment Verification Checklist](deployment-verification.md).
 
-**Troubleshooting**: see [rbw locked](#rbw-locked), [Vaultwarden unreachable](#vaultwarden-unreachable), [chezmoi conflicts](#chezmoi-conflicts).
+**Troubleshooting**: see [missing prereqs](#missing-prereqs--fresh-machine), [rbw locked](#rbw-locked), [Vaultwarden unreachable](#vaultwarden-unreachable), [chezmoi conflicts](#chezmoi-conflicts).
 
 ---
 
@@ -190,6 +199,12 @@ echo "${BEGET_CONTEXT:-unset}"  # → unset
 **Fresh bootstrap without network to Vaultwarden**
 
 ```bash
+# Step 1 is unchanged — still needed on a fresh machine (distro pkgs come
+# from apt/dnf, not from Vaultwarden).
+curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/scripts/install-prereqs.sh | sudo bash
+
+# Step 2 with --skip-secrets so rbw login/sync can be deferred until VW
+# is reachable.
 curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/install.sh | bash -s -- --role=workstation --skip-secrets
 ```
 
@@ -343,6 +358,58 @@ pattern).
 ---
 
 ## Troubleshooting
+
+### Missing prereqs — fresh machine
+
+**Symptom**: `install.sh` exits quickly (well under a second) with exit
+code `3` and a message like:
+
+```
+ERROR: missing root-installed prerequisites.
+  packages: pinentry-curses libssl-dev build-essential
+
+To remediate, run as root (or via sudo):
+  curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/scripts/install-prereqs.sh | sudo bash
+
+Or install the packages manually with your distro package manager.
+Then re-run:
+  curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/install.sh | bash
+```
+
+On Rocky, the message may additionally list a `repo:` line for EPEL or CRB
+if those aren't enabled.
+
+**Cause**: You jumped straight to step 2 of the Fresh Machine Bootstrap
+without running the step-1 prereq installer first. Per issue #100,
+`install.sh` is explicitly user-local — it detects the missing distro
+packages up front and exits with remediation rather than hanging on an
+invisible `sudo` password prompt (the failure mode that originally
+drove #100 in containers without passwordless sudo).
+
+**Fix — the normal case**:
+
+Copy-paste the command from the remediation block (it's the same one-liner
+§1 documents). Then re-run `install.sh`:
+
+```bash
+curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/scripts/install-prereqs.sh | sudo bash
+curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/install.sh | bash -s -- --role=workstation
+```
+
+**Fix — CI / automation / immutable images**:
+
+If the packages are already present by construction (a provisioned VM,
+a pre-baked container image, a config-management tool that runs before
+`install.sh`), pass `--skip-prereqs` to bypass the scan:
+
+```bash
+curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/install.sh | bash -s -- --skip-prereqs
+```
+
+`--skip-prereqs` only skips the up-front detection; it does not change
+the packages `install.sh` ultimately depends on. If they genuinely are
+not installed, later steps (e.g. `cargo install rbw`) will fail with
+their own errors.
 
 ### smoke: one-liner canary failing
 

--- a/install.sh
+++ b/install.sh
@@ -217,11 +217,15 @@ expected_distro_pkgs() {
                 build-essential
             ;;
         rocky | rhel | centos | almalinux)
+            # pkgconf-pkg-config is the RPM that installs /usr/bin/pkg-config
+            # on RHEL-family. `dnf install pkg-config` also works (Provides
+            # metadata), but `rpm -q pkg-config` does NOT — our scan uses
+            # rpm -q via distro_pkg_installed, so we must name the real pkg.
             printf '%s\n' \
                 pinentry \
                 git \
                 curl \
-                pkg-config \
+                pkgconf-pkg-config \
                 openssl-devel \
                 gcc
             ;;

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,16 @@
 #   --dry-run        Show what would happen without mutating the system.
 #   --role=<X>       Pass a role tag (workstation|server|minimal) to chezmoi.
 #   --skip-secrets   Bootstrap without rbw login or secret materialization.
+#   --skip-prereqs   Bypass the preflight scan for distro-managed packages.
+#                    Intended for CI/automation environments that have
+#                    already run scripts/install-prereqs.sh.
 #   --allow-root     Permit running as root (refused by default).
 #   --help           Print usage and exit.
+#
+# This script is PURELY USER-LOCAL — it never calls sudo. Distro-level
+# (root-requiring) packages are installed by scripts/install-prereqs.sh.
+# If any distro prereq is missing, preflight_root_requirements exits with
+# code 3 and a copy-pasteable remediation command.
 #
 # Environment overrides (test seams):
 #   BEGET_RAW_BASE   When set, locate_lib_platform() fetches lib/platform.sh
@@ -25,7 +33,7 @@
 set -euo pipefail
 
 # When piped via `curl ... | bash`, bash's fd 0 is the pipe, so anything the
-# script spawns (rbw login, sudo) cannot prompt the user. Reparent fd 0 to the
+# script spawns (rbw login) cannot prompt the user. Reparent fd 0 to the
 # controlling terminal when one exists. The `|| true` catches the case where
 # /dev/tty is present but not openable (no controlling terminal — headless CI,
 # some container runtimes, sandboxed subshells). BEGET_SKIP_TTY_REPARENT lets
@@ -42,20 +50,11 @@ readonly BEGET_REPO_URL="https://github.com/bakeb7j0/beget"
 # one-liner test (E2E-09) uses this to point at a loopback HTTP server.
 readonly BEGET_RAW_BASE="${BEGET_RAW_BASE:-}"
 readonly REQUIRED_TOOLS=(curl git bash)
-# Distro-managed prereqs — routed through apt/dnf via pkg_install.
-# The curses/TTY pinentry is resolved per-distro by
-# pkg_name_pinentry_tty() (Ubuntu: pinentry-curses, Rocky: pinentry)
-# so we build the list dynamically in install_prereqs rather than
-# baking a Debian-centric constant. pinentry-gnome3 is appended
-# conditionally when running under GNOME.
-# direnv is intentionally NOT here: it's in Ubuntu's apt repos but not
-# in Rocky 9 (base or EPEL), so the upstream installer is the only
-# uniform path across both distros.
-# Upstream prereqs — none of chezmoi, direnv, or rbw is uniformly
-# available in Ubuntu/Rocky default repos, so each has a dedicated
-# installer in lib/platform.sh (install_chezmoi, install_direnv,
-# install_rbw).
-readonly UPSTREAM_PREREQS=(chezmoi direnv rbw)
+
+# Exit code emitted by preflight_root_requirements when any distro
+# package is missing. Distinct from die()'s generic exit 1 so CI and
+# users can distinguish "run install-prereqs.sh first" from real errors.
+readonly EXIT_MISSING_PREREQS=3
 
 # ---- Helpers -----------------------------------------------------------------
 
@@ -79,10 +78,16 @@ Options:
   --role=<X>        Role tag to pass to chezmoi (workstation|server|minimal).
                     Defaults to "workstation".
   --skip-secrets    Skip rbw login and secret materialization.
+  --skip-prereqs    Bypass preflight scan for distro-managed packages
+                    (intended for CI that already ran install-prereqs.sh).
   --skip-apply      Stop after chezmoi init; skip the final 'chezmoi apply'.
                     Useful for staged rollouts and CI bootstrap tests.
   --allow-root      Allow execution as root (refused by default, R-03).
   --help            Show this help and exit.
+
+install.sh is purely user-local: it does not invoke sudo. On fresh
+machines, run scripts/install-prereqs.sh as root first to install
+distro packages, then run this script as your unprivileged user.
 
 Example:
   curl -fsSL https://github.com/bakeb7j0/beget/raw/HEAD/install.sh \
@@ -126,6 +131,7 @@ DRY_RUN=0
 ROLE="workstation"
 SKIP_SECRETS=0
 SKIP_APPLY=0
+SKIP_PREREQS=0
 ALLOW_ROOT=0
 
 parse_flags() {
@@ -136,6 +142,7 @@ parse_flags() {
             --role=*) ROLE="${arg#--role=}" ;;
             --skip-secrets) SKIP_SECRETS=1 ;;
             --skip-apply) SKIP_APPLY=1 ;;
+            --skip-prereqs) SKIP_PREREQS=1 ;;
             --allow-root) ALLOW_ROOT=1 ;;
             --help | -h)
                 usage
@@ -193,33 +200,128 @@ preflight() {
     log "pre-flight OK: role=${ROLE} os=${OS_ID}:${OS_MAJOR_VERSION} dry_run=${DRY_RUN} skip_secrets=${SKIP_SECRETS}"
 }
 
-# ---- Prereq install ----------------------------------------------------------
+# ---- Preflight: distro-level prerequisite scan -------------------------------
 
-install_prereqs() {
-    # Build the distro-prereq list now that OS_ID is known (preflight
-    # has already sourced /etc/os-release). pkg_name_pinentry_tty()
-    # lives in lib/platform.sh and resolves the curses-pinentry name
-    # per-distro.
-    local pkgs=("$(pkg_name_pinentry_tty)" git curl)
-
-    # pinentry-gnome3 is only meaningful on GNOME desktops.
+# Emit the expected distro package list for the detected OS (+ optional
+# GNOME desktop pinentry). Called by preflight_root_requirements to
+# build the "must be installed" set. OS_ID must already be populated.
+expected_distro_pkgs() {
+    case "$OS_ID" in
+        ubuntu | debian)
+            printf '%s\n' \
+                pinentry-curses \
+                git \
+                curl \
+                pkg-config \
+                libssl-dev \
+                build-essential
+            ;;
+        rocky | rhel | centos | almalinux)
+            printf '%s\n' \
+                pinentry \
+                git \
+                curl \
+                pkg-config \
+                openssl-devel \
+                gcc
+            ;;
+        *)
+            die "expected_distro_pkgs: unsupported OS_ID: $OS_ID"
+            ;;
+    esac
     if is_gnome; then
-        pkgs+=(pinentry-gnome3)
+        printf '%s\n' pinentry-gnome3
+    fi
+}
+
+# Return 0 if $1 is installed, 1 otherwise. Dispatches per OS_ID.
+distro_pkg_installed() {
+    local pkg="$1"
+    case "$OS_ID" in
+        ubuntu | debian)
+            dpkg -s "$pkg" >/dev/null 2>&1
+            ;;
+        rocky | rhel | centos | almalinux)
+            rpm -q "$pkg" >/dev/null 2>&1
+            ;;
+        *)
+            die "distro_pkg_installed: unsupported OS_ID: $OS_ID"
+            ;;
+    esac
+}
+
+# Return 0 if the named dnf repo is enabled, 1 otherwise. Rocky/RHEL only.
+rocky_repo_enabled() {
+    local repo="$1"
+    command -v dnf >/dev/null 2>&1 || return 1
+    dnf repolist --enabled 2>/dev/null | awk '{print $1}' | grep -Fxq "$repo"
+}
+
+# Scan for missing distro packages and exit with EXIT_MISSING_PREREQS if
+# any are missing. On success (all present), returns 0 silently.
+# Honors --skip-prereqs by returning 0 immediately.
+preflight_root_requirements() {
+    if [[ "$SKIP_PREREQS" -eq 1 ]]; then
+        log "skipping preflight_root_requirements (--skip-prereqs)"
+        return 0
     fi
 
-    if [[ "$DRY_RUN" -eq 1 ]]; then
-        log "[dry-run] would ensure EPEL on RHEL-family"
-        log "[dry-run] would pkg_install: ${pkgs[*]}"
-        log "[dry-run] would install upstream prereqs: ${UPSTREAM_PREREQS[*]}"
-    else
-        # direnv (and some other userspace tooling) live in EPEL on
-        # Rocky/RHEL, so EPEL has to be enabled before pkg_install
-        # runs. Noop on Debian-family.
-        pkg_ensure_epel || die "EPEL enablement failed"
-        log "installing distro prereqs: ${pkgs[*]}"
-        pkg_install "${pkgs[@]}" || die "distro prereq install failed"
+    local expected missing=()
+    expected=$(expected_distro_pkgs)
+
+    local pkg
+    while IFS= read -r pkg; do
+        [[ -n "$pkg" ]] || continue
+        if ! distro_pkg_installed "$pkg"; then
+            missing+=("$pkg")
+        fi
+    done <<<"$expected"
+
+    # Rocky-only: EPEL + CRB. Missing either one blocks rbw/direnv builds
+    # downstream, so we surface them alongside missing packages.
+    local repo_hints=()
+    case "$OS_ID" in
+        rocky | rhel | centos | almalinux)
+            if ! distro_pkg_installed epel-release; then
+                missing+=(epel-release)
+            fi
+            if ! rocky_repo_enabled crb; then
+                repo_hints+=("enable CRB repo: dnf config-manager --set-enabled crb")
+            fi
+            ;;
+    esac
+
+    if [[ ${#missing[@]} -eq 0 && ${#repo_hints[@]} -eq 0 ]]; then
+        log "distro prereqs OK: $(echo "$expected" | tr '\n' ' ')"
+        return 0
     fi
 
+    # Build the copy-pasteable remediation. Prefer the one-step
+    # install-prereqs.sh pointer so users don't have to track the
+    # full pkg list themselves.
+    printf 'ERROR: missing root-installed prerequisites.\n' >&2
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        printf '  packages: %s\n' "${missing[*]}" >&2
+    fi
+    if [[ ${#repo_hints[@]} -gt 0 ]]; then
+        local hint
+        for hint in "${repo_hints[@]}"; do
+            printf '  repo: %s\n' "$hint" >&2
+        done
+    fi
+    printf '\n' >&2
+    printf 'To remediate, run as root (or via sudo):\n' >&2
+    printf '  curl -fsSL %s/raw/HEAD/scripts/install-prereqs.sh | sudo bash\n' "$BEGET_REPO_URL" >&2
+    printf '\n' >&2
+    printf 'Or install the packages manually with your distro package manager.\n' >&2
+    printf 'Then re-run:\n' >&2
+    printf '  curl -fsSL %s/raw/HEAD/install.sh | bash\n' "$BEGET_REPO_URL" >&2
+    exit "$EXIT_MISSING_PREREQS"
+}
+
+# ---- User-local installs (chezmoi, direnv, rbw) ------------------------------
+
+install_user_local() {
     install_chezmoi || die "chezmoi install failed"
     install_direnv || die "direnv install failed"
     install_rbw || die "rbw install failed"
@@ -320,7 +422,8 @@ main() {
     source "$lib_path"
 
     preflight
-    install_prereqs
+    preflight_root_requirements
+    install_user_local
     write_chezmoi_config
     chezmoi_bootstrap
     rbw_prompt_if_needed

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -1,25 +1,27 @@
 #!/usr/bin/env bash
-# lib/platform.sh — OS detection and package manager abstraction
+# lib/platform.sh — OS detection and user-local installers.
 #
 # Sourced library. Do NOT set -euo pipefail globally here — a library must
 # not alter the caller's shell options. Individual functions use `local`
 # variables and explicit return codes.
 #
+# This library intentionally contains ZERO sudo calls. Distro-level
+# (root-requiring) packages are installed by scripts/install-prereqs.sh
+# in a separate, explicit step; install.sh scans for them in preflight
+# and exits with actionable guidance if anything is missing. See #100.
+#
 # Public functions:
 #   source_os_release          — populate OS_ID and OS_MAJOR_VERSION
-#   pkg_install <pkg>...       — install packages via apt-get or dnf
-#   pkg_repo_add <url> <keyring_url> <name>
-#                              — register an apt or yum repo
+#   pkg_name_pinentry_tty      — print distro-appropriate curses pinentry pkg name
 #   is_gnome                   — return 0 if running under GNOME
 #   die_if_unsupported_os      — abort if OS is not Ubuntu 24.04 or Rocky 9
 #   install_chezmoi            — install chezmoi via upstream get.chezmoi.io
 #   install_direnv             — install direnv via upstream direnv.net
+#   ensure_rust_toolchain      — install rustup + stable toolchain (user-local)
 #   install_rbw                — install rbw via cargo (builds toolchain if needed)
 #
 # Test seams (env-var overrides, default shown):
 #   OS_RELEASE_FILE        — /etc/os-release
-#   APT_SOURCES_DIR        — /etc/apt/sources.list.d
-#   YUM_REPOS_DIR          — /etc/yum.repos.d
 #   BEGET_CHEZMOI_INSTALLER — https://get.chezmoi.io
 #   BEGET_DIRENV_INSTALLER  — https://direnv.net/install.sh
 #   BEGET_RUSTUP_INSTALLER  — https://sh.rustup.rs
@@ -58,42 +60,11 @@ source_os_release() {
     export OS_MAJOR_VERSION="$major"
 }
 
-# Refresh the package manager's metadata cache. Cheap on an up-to-date
-# system and essential on one with stale / empty lists (e.g. a minimal
-# container with /var/lib/apt/lists/ pruned, or a long-idle VM). Called
-# automatically by pkg_install on first invocation per process.
-_pkg_cache_refreshed=0
-pkg_cache_refresh() {
-    if [[ "$_pkg_cache_refreshed" -eq 1 ]]; then
-        return 0
-    fi
-
-    if [[ -z "${OS_ID:-}" ]]; then
-        source_os_release
-    fi
-
-    case "$OS_ID" in
-        ubuntu | debian)
-            sudo apt-get update -qq
-            ;;
-        rocky | rhel | centos | almalinux | fedora)
-            # dnf makecache is a noop when metadata is fresh; honor its
-            # own age heuristics rather than forcing a full refresh.
-            sudo dnf makecache -q
-            ;;
-        *)
-            die "pkg_cache_refresh: unsupported OS_ID: $OS_ID"
-            ;;
-    esac
-
-    _pkg_cache_refreshed=1
-}
-
 # Resolve the distro-appropriate package name for the curses/TTY
 # pinentry. Debian/Ubuntu ship it as `pinentry-curses`; RHEL-family
 # dnf repos ship it as plain `pinentry` (no `-curses` suffix because
-# that's the only pinentry variant in the base repos). Callers emit
-# the returned name straight into pkg_install.
+# that's the only pinentry variant in the base repos). Consumed by
+# callers building distro-package lists for preflight scans.
 pkg_name_pinentry_tty() {
     if [[ -z "${OS_ID:-}" ]]; then
         source_os_release
@@ -102,77 +73,6 @@ pkg_name_pinentry_tty() {
         ubuntu | debian) printf 'pinentry-curses' ;;
         rocky | rhel | centos | almalinux | fedora) printf 'pinentry' ;;
         *) die "pkg_name_pinentry_tty: unsupported OS_ID: $OS_ID" ;;
-    esac
-}
-
-# Install one or more packages using the native package manager.
-# Dispatches based on OS_ID (populated by source_os_release).
-pkg_install() {
-    if [[ $# -eq 0 ]]; then
-        die "pkg_install: no packages specified"
-    fi
-
-    if [[ -z "${OS_ID:-}" ]]; then
-        source_os_release
-    fi
-
-    pkg_cache_refresh
-
-    case "$OS_ID" in
-        ubuntu | debian)
-            sudo apt-get install -y "$@"
-            ;;
-        rocky | rhel | centos | almalinux | fedora)
-            sudo dnf install -y "$@"
-            ;;
-        *)
-            die "pkg_install: unsupported OS_ID: $OS_ID"
-            ;;
-    esac
-}
-
-# Register an apt or yum repository.
-#   $1 — repo URL (apt: deb-line URL; yum: .repo file URL or base URL)
-#   $2 — keyring URL (apt: armored GPG; yum: RPM-GPG key URL)
-#   $3 — short name (used to derive the filename)
-pkg_repo_add() {
-    if [[ $# -lt 3 ]]; then
-        die "pkg_repo_add: usage: pkg_repo_add <url> <keyring_url> <name>"
-    fi
-
-    local url="$1"
-    local keyring_url="$2"
-    local name="$3"
-
-    if [[ -z "${OS_ID:-}" ]]; then
-        source_os_release
-    fi
-
-    local apt_dir="${APT_SOURCES_DIR:-/etc/apt/sources.list.d}"
-    local yum_dir="${YUM_REPOS_DIR:-/etc/yum.repos.d}"
-
-    case "$OS_ID" in
-        ubuntu | debian)
-            local keyring_path="/usr/share/keyrings/${name}.gpg"
-            local list_path="${apt_dir}/${name}.list"
-            # Fetch keyring separately: a sourced library can't set -o pipefail,
-            # so curl|gpg would silently swallow a curl failure and write an
-            # empty keyring. Fail fast instead.
-            local key_bytes
-            key_bytes=$(curl -fsSL "$keyring_url") ||
-                die "pkg_repo_add: failed to fetch keyring: $keyring_url"
-            printf '%s' "$key_bytes" | sudo gpg --dearmor -o "$keyring_path"
-            printf 'deb [signed-by=%s] %s\n' "$keyring_path" "$url" |
-                sudo tee "$list_path" >/dev/null
-            ;;
-        rocky | rhel | centos | almalinux | fedora)
-            local repo_path="${yum_dir}/${name}.repo"
-            sudo curl -fsSL -o "$repo_path" "$url"
-            sudo rpm --import "$keyring_url"
-            ;;
-        *)
-            die "pkg_repo_add: unsupported OS_ID: $OS_ID"
-            ;;
     esac
 }
 
@@ -198,38 +98,6 @@ _prepend_path() {
         *":${dir}:"*) return 0 ;;
     esac
     export PATH="${dir}:${PATH}"
-}
-
-# On RHEL-family systems, ensure the EPEL repository is enabled.
-# Several distro-layer prereqs (direnv most notably) live in EPEL rather
-# than base — a fresh Rocky/RHEL install has no `direnv` package until
-# EPEL is added. Noop on Debian-family. Honors DRY_RUN.
-pkg_ensure_epel() {
-    if [[ -z "${OS_ID:-}" ]]; then
-        source_os_release
-    fi
-
-    case "$OS_ID" in
-        rocky | rhel | centos | almalinux)
-            if rpm -q epel-release >/dev/null 2>&1; then
-                log_platform "epel-release already installed"
-            elif [[ "${DRY_RUN:-0}" -eq 1 ]]; then
-                log_platform "[dry-run] would dnf install -y epel-release"
-                log_platform "[dry-run] would dnf config-manager --set-enabled crb"
-                return 0
-            else
-                log_platform "enabling EPEL repository via epel-release"
-                sudo dnf install -y epel-release
-            fi
-            # Most EPEL userspace packages (direnv among them) depend on
-            # CRB (CodeReady Builder; disabled by default on Rocky/RHEL).
-            log_platform "ensuring CRB repository is enabled"
-            sudo dnf config-manager --set-enabled crb
-            ;;
-        *)
-            return 0
-            ;;
-    esac
 }
 
 # Install chezmoi via the upstream installer (user-local, no sudo).
@@ -327,10 +195,11 @@ ensure_rust_toolchain() {
 }
 
 # Install rbw via cargo. Noop when rbw is already on PATH. Honors DRY_RUN.
-# Installs native build deps (pkg-config, openssl dev headers, C compiler)
-# via pkg_install, then ensures a modern Rust toolchain through rustup
-# (distro cargo on Ubuntu 24.04 / Rocky 9 is too old — see
-# ensure_rust_toolchain), and finally invokes `cargo install rbw --locked`.
+# The native build deps (pkg-config, openssl dev headers, C compiler) are
+# expected to be pre-installed by scripts/install-prereqs.sh and verified
+# by install.sh's preflight_root_requirements scan. A modern Rust toolchain
+# is ensured through rustup (distro cargo on Ubuntu 24.04 / Rocky 9 is too
+# old — see ensure_rust_toolchain), then we invoke `cargo install rbw --locked`.
 install_rbw() {
     local cargo_bindir="${HOME}/.cargo/bin"
 
@@ -339,32 +208,11 @@ install_rbw() {
         return 0
     fi
 
-    if [[ -z "${OS_ID:-}" ]]; then
-        source_os_release
-    fi
-
-    local -a build_deps
-    case "$OS_ID" in
-        ubuntu | debian)
-            build_deps=(pkg-config libssl-dev build-essential)
-            ;;
-        rocky | rhel | centos | almalinux | fedora)
-            build_deps=(pkg-config openssl-devel gcc)
-            ;;
-        *)
-            die "install_rbw: unsupported OS_ID: $OS_ID"
-            ;;
-    esac
-
     if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
-        log_platform "[dry-run] would pkg_install rbw build deps: ${build_deps[*]}"
         log_platform "[dry-run] would ensure rust toolchain via rustup"
         log_platform "[dry-run] would cargo install rbw --locked into ${cargo_bindir}"
         return 0
     fi
-
-    log_platform "installing rbw build deps: ${build_deps[*]}"
-    pkg_install "${build_deps[@]}"
 
     ensure_rust_toolchain
 

--- a/run_onchange_before_20-packages-common.sh
+++ b/run_onchange_before_20-packages-common.sh
@@ -13,16 +13,24 @@
 #   workstation → installs common + workstation
 #   (default)   → installs common only
 #
-# Idempotency: the underlying `pkg_install` delegates to `apt-get install -y`
-# or `dnf install -y`, both of which are no-ops when the package is already at
+# Idempotency: the default installer delegates to `apt-get install -y` or
+# `dnf install -y`, both of which are no-ops when the package is already at
 # the requested version.
+#
+# Root access: this hook needs root to install packages. Unlike install.sh
+# (which is strictly user-local post-#100), chezmoi apply is an interactive
+# step the user runs knowingly, so BEGET_SUDO=sudo is safe here. Tests
+# stub the installer wholesale via BEGET_PKG_INSTALL.
 #
 # Test seams (env-var overrides):
 #   BEGET_ROLE           — role selector (default: workstation)
 #   BEGET_PACKAGE_DIR    — directory containing apt-packages-*.list
 #                          (default: $HOME/.local/share/beget)
-#   BEGET_PKG_INSTALL    — function name to invoke (default: pkg_install)
+#   BEGET_PKG_INSTALL    — function name to invoke (default: beget_pkg_install)
 #                          override allows unit tests to capture invocations.
+#   BEGET_SUDO           — sudo (production); tests typically override
+#                          BEGET_PKG_INSTALL instead of mocking sudo.
+#   OS_RELEASE_FILE      — os-release file path (default /etc/os-release)
 #
 # chezmoi injects the following hashes so this script re-runs on any list edit:
 #   common:      {{ include "share/apt-packages-common.list" | sha256sum }}
@@ -32,16 +40,33 @@
 
 set -euo pipefail
 
-REPO_LIB_DIR="${BEGET_LIB_DIR:-${HOME}/.local/share/beget/lib}"
 PACKAGE_DIR="${BEGET_PACKAGE_DIR:-${HOME}/.local/share/beget}"
 ROLE="${BEGET_ROLE:-workstation}"
+BEGET_SUDO="${BEGET_SUDO:-sudo}"
 
-# Source lib/platform.sh for pkg_install. In production chezmoi lays this file
-# out under ~/.local/share/beget/lib/platform.sh; tests override BEGET_LIB_DIR.
-if [[ -r "${REPO_LIB_DIR}/platform.sh" ]]; then
-    # shellcheck source=/dev/null
-    source "${REPO_LIB_DIR}/platform.sh"
-fi
+# Default installer: dispatch to apt-get or dnf based on /etc/os-release.
+# This is self-contained (no dependency on lib/platform.sh) because #100
+# keeps platform.sh sudo-free. Tests override via BEGET_PKG_INSTALL.
+beget_pkg_install() {
+    local os_release_file="${OS_RELEASE_FILE:-/etc/os-release}"
+    local id=""
+    if [[ -r "$os_release_file" ]]; then
+        # shellcheck disable=SC1090
+        id=$(. "$os_release_file" && printf '%s' "${ID:-}")
+    fi
+    case "$id" in
+        ubuntu | debian)
+            $BEGET_SUDO apt-get install -y "$@"
+            ;;
+        rocky | rhel | centos | almalinux | fedora)
+            $BEGET_SUDO dnf install -y "$@"
+            ;;
+        *)
+            printf 'run_onchange_before_20-packages-common: unsupported OS %s, cannot install packages\n' "${id:-unknown}" >&2
+            return 1
+            ;;
+    esac
+}
 
 # Read a package list file and emit one package name per line, skipping blank
 # lines and `#` comment lines. Leading/trailing whitespace is stripped so that
@@ -76,7 +101,7 @@ install_from_list() {
         return 0
     fi
 
-    local installer="${BEGET_PKG_INSTALL:-pkg_install}"
+    local installer="${BEGET_PKG_INSTALL:-beget_pkg_install}"
     "$installer" "${pkgs[@]}"
 }
 

--- a/scripts/ci/run-smoke-canary.sh
+++ b/scripts/ci/run-smoke-canary.sh
@@ -40,13 +40,16 @@ image="beget-e2e:${distro}"
 docker build -f "$dockerfile" -t "$image" .
 
 # The bootstrap command the README promises. Runs as the Dockerfile's
-# beget user (uid 1000) because install.sh shells out to sudo apt/dnf,
-# and sudo needs an /etc/passwd entry matching the runtime uid. Pipe
-# to bash -s -- so install.sh parses its flags correctly.
+# beget user (uid 1000); per issue #100 install.sh is purely user-local
+# and invokes no sudo, so the uid choice is just convention with
+# run-e2e.sh. Distro prereqs (pinentry, build deps for rbw, etc.) were
+# baked into the image by `scripts/install-prereqs.sh` at build time —
+# the canary assumes the two-step user story (prereqs already installed)
+# and exercises only the user-local second step that `install.sh` owns.
 #
 # Post-install binary checks: chezmoi/rbw/direnv come from install.sh's
-# prereq phase; `glab` is expected from the chezmoi apply phase and is
-# asserted here per issue #98 AC — the original report (".bashrc and
+# user-local phase; `glab` is expected from the chezmoi apply phase and
+# is asserted here per issue #98 AC — the original report (".bashrc and
 # adjacent files ... glab is not installed") traced back to an aborted
 # chezmoi apply, so a missing glab is the canonical symptom of the
 # post-merge install-path regression this canary exists to catch.

--- a/scripts/install-prereqs.sh
+++ b/scripts/install-prereqs.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# scripts/install-prereqs.sh — install the distro-level (root-requiring)
+# prerequisites that install.sh needs. Must be run as root (or via sudo).
+#
+# install.sh is purely user-local and no longer invokes sudo itself. On
+# fresh machines, run this script once (it's the only root-requiring step
+# in the whole bootstrap), then run install.sh as the unprivileged user.
+#
+# Usage:
+#     sudo bash scripts/install-prereqs.sh [--dry-run]
+#   or one-liner:
+#     curl -fsSL https://raw.githubusercontent.com/bakeb7j0/beget/main/scripts/install-prereqs.sh | sudo bash
+#
+# Flags:
+#   --dry-run   Print the commands that would be run, without executing them.
+#   --help      Show this help and exit.
+#
+# Packages installed (matches what install.sh + chezmoi templates need):
+#   Ubuntu 24.04: pinentry-curses git curl pkg-config libssl-dev
+#                 build-essential  (+ pinentry-gnome3 under GNOME)
+#   Rocky 9:      pinentry git curl pkg-config openssl-devel gcc
+#                 (+ pinentry-gnome3 under GNOME), plus epel-release and
+#                 the CRB repo enabled (EPEL userspace depends on CRB).
+#
+# Exit codes:
+#   0 — success
+#   1 — generic failure (package manager error, unsupported OS, etc.)
+#   2 — invoked as non-root while --dry-run was not set
+#
+# Test seams (env overrides):
+#   OS_RELEASE_FILE   — path to os-release file (default /etc/os-release)
+#   BEGET_PREREQS_PKG_CMD — override package-manager command for tests
+#
+# This script is intentionally self-contained: it does not source
+# lib/platform.sh, so users can `curl | sudo bash` it without having the
+# repo checked out first.
+
+set -euo pipefail
+
+DRY_RUN=0
+USAGE=$(
+    cat <<'EOF'
+Usage: install-prereqs.sh [--dry-run] [--help]
+
+Installs the distro-level prerequisites that install.sh needs. Must be
+run as root (or via sudo); see `--dry-run` for a preview without root.
+EOF
+)
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+log() {
+    printf '[install-prereqs] %s\n' "$*"
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run) DRY_RUN=1 ;;
+            --help | -h)
+                printf '%s\n' "$USAGE"
+                exit 0
+                ;;
+            *) die "unknown argument: $1 (try --help)" ;;
+        esac
+        shift
+    done
+}
+
+require_root() {
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        return 0
+    fi
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        printf 'ERROR: this script must be run as root (or via sudo).\n' >&2
+        printf 'Try: sudo bash %s\n' "$0" >&2
+        exit 2
+    fi
+}
+
+detect_os() {
+    local os_release_file="${OS_RELEASE_FILE:-/etc/os-release}"
+    if [[ ! -r "$os_release_file" ]]; then
+        die "cannot read os-release file: $os_release_file"
+    fi
+
+    local version_id
+    # shellcheck disable=SC1090
+    OS_ID=$(. "$os_release_file" && printf '%s' "${ID:-}")
+    # shellcheck disable=SC1090
+    version_id=$(. "$os_release_file" && printf '%s' "${VERSION_ID:-}")
+
+    [[ -n "${OS_ID}" ]] || die "os-release missing ID field"
+    OS_MAJOR_VERSION="${version_id%%.*}"
+}
+
+is_gnome() {
+    local desktop="${XDG_CURRENT_DESKTOP:-}"
+    [[ "${desktop,,}" == *gnome* ]]
+}
+
+run_cmd() {
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        log "[dry-run] $*"
+        return 0
+    fi
+    log "+ $*"
+    "$@"
+}
+
+install_ubuntu() {
+    local pkgs=(pinentry-curses git curl pkg-config libssl-dev build-essential)
+    if is_gnome; then
+        pkgs+=(pinentry-gnome3)
+    fi
+
+    run_cmd apt-get update -qq
+    run_cmd apt-get install -y "${pkgs[@]}"
+}
+
+install_rocky() {
+    local pkgs=(pinentry git curl pkg-config openssl-devel gcc)
+    if is_gnome; then
+        pkgs+=(pinentry-gnome3)
+    fi
+
+    # EPEL first, then CRB. Several chezmoi-layer tools (direnv most
+    # notably) live in EPEL, which itself depends on CRB being enabled.
+    if [[ "${DRY_RUN}" -eq 1 ]] || ! rpm -q epel-release >/dev/null 2>&1; then
+        run_cmd dnf install -y epel-release
+    else
+        log "epel-release already installed"
+    fi
+    run_cmd dnf config-manager --set-enabled crb
+
+    run_cmd dnf makecache -q
+    run_cmd dnf install -y "${pkgs[@]}"
+}
+
+main() {
+    parse_args "$@"
+    require_root
+    detect_os
+
+    log "detected OS: ${OS_ID} ${OS_MAJOR_VERSION}"
+
+    case "${OS_ID}" in
+        ubuntu | debian)
+            install_ubuntu
+            ;;
+        rocky | rhel | centos | almalinux)
+            install_rocky
+            ;;
+        *)
+            die "unsupported OS: ${OS_ID} (expected ubuntu or rocky/rhel)"
+            ;;
+    esac
+
+    log "prereqs installed. Now run install.sh as your unprivileged user:"
+    log "    curl -fsSL https://raw.githubusercontent.com/bakeb7j0/beget/main/install.sh | bash"
+}
+
+main "$@"

--- a/scripts/install-prereqs.sh
+++ b/scripts/install-prereqs.sh
@@ -18,9 +18,11 @@
 # Packages installed (matches what install.sh + chezmoi templates need):
 #   Ubuntu 24.04: pinentry-curses git curl pkg-config libssl-dev
 #                 build-essential  (+ pinentry-gnome3 under GNOME)
-#   Rocky 9:      pinentry git curl pkg-config openssl-devel gcc
+#   Rocky 9:      pinentry git curl pkgconf-pkg-config openssl-devel gcc
 #                 (+ pinentry-gnome3 under GNOME), plus epel-release and
 #                 the CRB repo enabled (EPEL userspace depends on CRB).
+#                 (pkgconf-pkg-config is the RPM that provides pkg-config —
+#                 install.sh's preflight scans by rpm -q, not by Provides.)
 #
 # Exit codes:
 #   0 — success
@@ -122,7 +124,7 @@ install_ubuntu() {
 }
 
 install_rocky() {
-    local pkgs=(pinentry git curl pkg-config openssl-devel gcc)
+    local pkgs=(pinentry git curl pkgconf-pkg-config openssl-devel gcc)
     if is_gnome; then
         pkgs+=(pinentry-gnome3)
     fi

--- a/tests/e2e/Dockerfile.rocky9
+++ b/tests/e2e/Dockerfile.rocky9
@@ -15,11 +15,20 @@ RUN dnf install --allowerasing -yq \
         bash \
         ca-certificates \
         curl \
-        git \
         jq \
         python3 \
         sudo \
         tzdata
+
+# Install beget's distro-level prerequisites via the same script users run.
+# This bakes the root-owned packages (pinentry, EPEL+CRB, build deps for rbw,
+# etc.) into the image so `bash install.sh` at E2E time exits zero without
+# needing sudo — which is the whole point of issue #100. Doing it here also
+# acts as an image-build-time smoke test of install-prereqs.sh itself.
+COPY scripts/install-prereqs.sh /tmp/install-prereqs.sh
+RUN bash /tmp/install-prereqs.sh \
+    && rm -f /tmp/install-prereqs.sh \
+    && dnf clean all
 
 # Install chezmoi at a pinned version.
 RUN curl -fsSL get.chezmoi.io | sh -s -- -b /usr/local/bin -t v2.55.0

--- a/tests/e2e/Dockerfile.ubuntu24
+++ b/tests/e2e/Dockerfile.ubuntu24
@@ -21,12 +21,21 @@ RUN apt-get update -qq \
         bash \
         ca-certificates \
         curl \
-        git \
         jq \
         python3 \
         sudo \
         shellcheck \
         tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install beget's distro-level prerequisites via the same script users run.
+# This bakes the root-owned packages (pinentry-curses, build deps for rbw,
+# etc.) into the image so `bash install.sh` at E2E time exits zero without
+# needing sudo — which is the whole point of issue #100. Doing it here also
+# acts as an image-build-time smoke test of install-prereqs.sh itself.
+COPY scripts/install-prereqs.sh /tmp/install-prereqs.sh
+RUN bash /tmp/install-prereqs.sh \
+    && rm -f /tmp/install-prereqs.sh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install chezmoi at a pinned version. We skip rbw — tests that need it

--- a/tests/e2e/_lib.sh
+++ b/tests/e2e/_lib.sh
@@ -137,7 +137,7 @@ EOF
 # Invoke install.sh with preflight-only semantics: source it with
 # BEGET_INSTALL_SOURCED=1 so main() does not execute, then call
 # individual functions directly. Callers get access to parse_flags,
-# preflight, install_prereqs, etc.
+# preflight, preflight_root_requirements, install_user_local, etc.
 source_install() {
     local repo="${1:?repo path required}"
     export BEGET_INSTALL_SOURCED=1
@@ -149,7 +149,7 @@ source_install() {
     export BEGET_SKIP_TTY_REPARENT=1
     # install.sh defers sourcing lib/platform.sh until main(); since
     # we skip main(), bring platform.sh in directly so preflight /
-    # install_prereqs have source_os_release + friends available.
+    # install_user_local have source_os_release + friends available.
     # shellcheck source=/dev/null
     source "$repo/lib/platform.sh"
     # shellcheck source=/dev/null

--- a/tests/e2e/e2e-01-fresh-ubuntu-minimal.sh
+++ b/tests/e2e/e2e-01-fresh-ubuntu-minimal.sh
@@ -28,16 +28,22 @@ run_test() {
     assert_eq "$OS_ID" "ubuntu" "os_id" || return 1
     assert_eq "$OS_MAJOR_VERSION" "24" "os_major" || return 1
 
-    # install_prereqs in dry-run mode must emit both a distro pkg list
-    # and an upstream-installer marker but not actually invoke apt or
-    # cargo. The two-phase split is what fixes R-01 (chezmoi/rbw were
-    # never in the distro repos).
+    # Post-#100 the prereq model is split: distro packages come from
+    # scripts/install-prereqs.sh (baked into Dockerfile.ubuntu24 at build
+    # time), and install.sh's preflight_root_requirements is a read-only
+    # scan that exits 3 if anything is missing. On this image all
+    # packages are present, so the scan must return 0.
+    preflight_root_requirements || return 1
+
+    # install_user_local in dry-run mode must emit markers for all three
+    # upstream installers without actually invoking apt/cargo/curl. This
+    # is the "chezmoi/rbw were never in the distro repos" invariant that
+    # originally motivated R-01.
     local out
-    out="$(install_prereqs 2>&1)" || return 1
-    assert_match "$out" "would pkg_install" "distro dry-run marker" || return 1
-    assert_match "$out" "upstream prereqs" "upstream dry-run marker" || return 1
-    assert_match "$out" "chezmoi" "chezmoi mentioned" || return 1
-    assert_match "$out" "rbw" "rbw mentioned" || return 1
+    out="$(install_user_local 2>&1)" || return 1
+    assert_match "$out" "\[dry-run\] would install chezmoi" "chezmoi dry-run marker" || return 1
+    assert_match "$out" "\[dry-run\] would install direnv" "direnv dry-run marker" || return 1
+    assert_match "$out" "\[dry-run\] would cargo install rbw" "rbw dry-run marker" || return 1
 }
 
 start=$(date +%s)

--- a/tests/e2e/e2e-01-fresh-ubuntu-minimal.sh
+++ b/tests/e2e/e2e-01-fresh-ubuntu-minimal.sh
@@ -39,11 +39,16 @@ run_test() {
     # upstream installers without actually invoking apt/cargo/curl. This
     # is the "chezmoi/rbw were never in the distro repos" invariant that
     # originally motivated R-01.
+    #
+    # chezmoi is baked into Dockerfile.ubuntu24 for speed, so install_chezmoi
+    # hits the idempotency branch before DRY_RUN and logs "already installed"
+    # instead of the dry-run marker. Accept either — both prove install_user_local
+    # handled chezmoi. Same applies to direnv/rbw if a future image bakes them in.
     local out
     out="$(install_user_local 2>&1)" || return 1
-    assert_match "$out" "\[dry-run\] would install chezmoi" "chezmoi dry-run marker" || return 1
-    assert_match "$out" "\[dry-run\] would install direnv" "direnv dry-run marker" || return 1
-    assert_match "$out" "\[dry-run\] would cargo install rbw" "rbw dry-run marker" || return 1
+    assert_match "$out" "chezmoi already installed|\[dry-run\] would install chezmoi" "chezmoi marker" || return 1
+    assert_match "$out" "direnv already installed|\[dry-run\] would install direnv" "direnv marker" || return 1
+    assert_match "$out" "rbw already installed|\[dry-run\] would cargo install rbw" "rbw marker" || return 1
 }
 
 start=$(date +%s)

--- a/tests/e2e/e2e-02-fresh-ubuntu-workstation.sh
+++ b/tests/e2e/e2e-02-fresh-ubuntu-workstation.sh
@@ -19,20 +19,32 @@ run_test() {
     preflight || return 1
     assert_eq "$OS_ID" "ubuntu" || return 1
 
-    # Workstation role should include pinentry-gnome3 if GNOME, else
-    # base list only. XDG_CURRENT_DESKTOP is unset in the container so
-    # is_gnome returns 1 and we should NOT see pinentry-gnome3.
+    # Post-#100 the distro pkg list is computed by expected_distro_pkgs
+    # (consumed by preflight_root_requirements). GNOME dispatch there
+    # adds pinentry-gnome3; non-GNOME does not. Test both branches at
+    # the function-seam level — the installer image is deliberately
+    # non-GNOME, so we invoke expected_distro_pkgs directly rather than
+    # relying on the container's XDG env.
     unset XDG_CURRENT_DESKTOP
-    local out
-    out="$(install_prereqs 2>&1)" || return 1
-    assert_match "$out" "chezmoi" "prereqs mention chezmoi" || return 1
+    local base_list
+    base_list="$(expected_distro_pkgs)" || return 1
+    assert_match "$base_list" "pinentry-curses" "ubuntu base includes pinentry-curses" || return 1
+    if [[ "$base_list" == *pinentry-gnome3* ]]; then
+        _assert_fail "non-GNOME list should NOT contain pinentry-gnome3: $base_list"
+        return 1
+    fi
 
     # Force GNOME branch to confirm pinentry-gnome3 gets added.
-    # shellcheck disable=SC2034
-    export XDG_CURRENT_DESKTOP="GNOME"
-    local out2
-    out2="$(install_prereqs 2>&1)" || return 1
-    assert_match "$out2" "pinentry-gnome3" "GNOME branch adds pinentry-gnome3" || return 1
+    local gnome_list
+    gnome_list="$(XDG_CURRENT_DESKTOP=GNOME expected_distro_pkgs)" || return 1
+    assert_match "$gnome_list" "pinentry-gnome3" "GNOME branch adds pinentry-gnome3" || return 1
+
+    # install_user_local in dry-run must still log chezmoi/direnv/rbw
+    # intent (the user-local half of the split). preflight_root_requirements
+    # itself is tested in E2E-15 and install.bats.
+    local out
+    out="$(install_user_local 2>&1)" || return 1
+    assert_match "$out" "chezmoi" "dry-run mentions chezmoi" || return 1
 }
 
 start=$(date +%s)

--- a/tests/e2e/e2e-03-fresh-rocky-workstation.sh
+++ b/tests/e2e/e2e-03-fresh-rocky-workstation.sh
@@ -17,10 +17,29 @@ run_test() {
     assert_eq "$OS_ID" "rocky" "os_id (expect rocky on Dockerfile.rocky9)" || return 1
     assert_eq "$OS_MAJOR_VERSION" "9" "os_major" || return 1
 
+    # Post-#100 the distro pkg list for Rocky is computed by
+    # expected_distro_pkgs — pinentry (no -curses suffix), pkg-config,
+    # openssl-devel, gcc, etc. Ubuntu-only packages must not appear.
+    local pkgs
+    pkgs="$(expected_distro_pkgs)" || return 1
+    assert_match "$pkgs" "openssl-devel" "rocky list has openssl-devel" || return 1
+    assert_match "$pkgs" "gcc" "rocky list has gcc" || return 1
+    if [[ "$pkgs" == *libssl-dev* || "$pkgs" == *build-essential* ]]; then
+        _assert_fail "rocky list leaked ubuntu-only pkgs: $pkgs"
+        return 1
+    fi
+
+    # preflight_root_requirements is a read-only scan; in the Rocky E2E
+    # image scripts/install-prereqs.sh has already baked in the expected
+    # packages + EPEL + CRB, so the scan must exit 0 cleanly.
+    preflight_root_requirements || return 1
+
+    # install_user_local in dry-run must still log the upstream installer
+    # intent. These are the same across distros (chezmoi/direnv/rbw all
+    # come from upstream installers, not dnf).
     local out
-    out="$(install_prereqs 2>&1)" || return 1
-    # Dry-run marker should appear -- the pkg list itself may vary.
-    assert_match "$out" "pkg_install" "install_prereqs dispatched" || return 1
+    out="$(install_user_local 2>&1)" || return 1
+    assert_match "$out" "\[dry-run\] would cargo install rbw" "rbw dry-run marker" || return 1
 }
 
 start=$(date +%s)

--- a/tests/e2e/e2e-03-fresh-rocky-workstation.sh
+++ b/tests/e2e/e2e-03-fresh-rocky-workstation.sh
@@ -18,12 +18,16 @@ run_test() {
     assert_eq "$OS_MAJOR_VERSION" "9" "os_major" || return 1
 
     # Post-#100 the distro pkg list for Rocky is computed by
-    # expected_distro_pkgs — pinentry (no -curses suffix), pkg-config,
-    # openssl-devel, gcc, etc. Ubuntu-only packages must not appear.
+    # expected_distro_pkgs — pinentry (no -curses suffix),
+    # pkgconf-pkg-config (the RPM that provides /usr/bin/pkg-config;
+    # `pkg-config` is only a Provides, not a real package name, and our
+    # rpm -q scan needs the real name), openssl-devel, gcc. Ubuntu-only
+    # packages must not appear.
     local pkgs
     pkgs="$(expected_distro_pkgs)" || return 1
     assert_match "$pkgs" "openssl-devel" "rocky list has openssl-devel" || return 1
     assert_match "$pkgs" "gcc" "rocky list has gcc" || return 1
+    assert_match "$pkgs" "pkgconf-pkg-config" "rocky list uses real RPM name for pkg-config" || return 1
     if [[ "$pkgs" == *libssl-dev* || "$pkgs" == *build-essential* ]]; then
         _assert_fail "rocky list leaked ubuntu-only pkgs: $pkgs"
         return 1

--- a/tests/e2e/e2e-05-rerun-idempotency.sh
+++ b/tests/e2e/e2e-05-rerun-idempotency.sh
@@ -28,11 +28,17 @@ run_test() {
     assert_eq "$SKIP_SECRETS" "$skip1" "skip_secrets stable" || return 1
     assert_eq "$OS_ID" "$os1" "os_id stable" || return 1
 
-    # install_prereqs should be idempotent in dry-run too.
+    # Post-#100 the equivalent idempotency contract is on the two new
+    # function seams: preflight_root_requirements (read-only scan —
+    # identical rc and log every time) and install_user_local in
+    # dry-run (logs intent only, must be stable across re-runs).
+    preflight_root_requirements || return 1
+    preflight_root_requirements || return 1
+
     local out1 out2
-    out1="$(install_prereqs 2>&1)" || return 1
-    out2="$(install_prereqs 2>&1)" || return 1
-    assert_eq "$out1" "$out2" "install_prereqs output stable across re-runs" || return 1
+    out1="$(install_user_local 2>&1)" || return 1
+    out2="$(install_user_local 2>&1)" || return 1
+    assert_eq "$out1" "$out2" "install_user_local output stable across re-runs" || return 1
 }
 
 start=$(date +%s)

--- a/tests/e2e/e2e-15-missing-prereqs-fail-fast.sh
+++ b/tests/e2e/e2e-15-missing-prereqs-fail-fast.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# tests/e2e/e2e-15-missing-prereqs-fail-fast.sh -- E2E-15.
+#
+# Requirement: Issue #100. install.sh must be purely user-local — no
+# sudo invocations. When a distro-level prereq is missing, the script
+# must exit with code 3 and print a copy-pasteable remediation command
+# rather than either (a) calling sudo itself or (b) hanging on an
+# invisible sudo password prompt.
+#
+# This is a function-level seam test: we source install.sh with
+# BEGET_INSTALL_SOURCED=1 and invoke preflight_root_requirements
+# directly, stubbing distro_pkg_installed to simulate a missing
+# pinentry. A `sudo` stub on PATH exits 77 if ever invoked, so any
+# accidental regression that reintroduces a sudo call will be caught.
+#
+# Pairs with E2E-13/14 (the Issue #98 seams).
+
+set -uo pipefail
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$REPO/tests/e2e/_lib.sh"
+
+install_failing_sudo_stub() {
+    # A sudo stub that exits non-zero on ANY invocation. install.sh must
+    # never invoke it (the whole point of #100).
+    local shim_dir="$1"
+    mkdir -p "$shim_dir"
+    cat >"$shim_dir/sudo" <<'EOF'
+#!/usr/bin/env bash
+echo "FAIL: sudo invoked from install.sh (args: $*)" >&2
+exit 77
+EOF
+    chmod +x "$shim_dir/sudo"
+}
+
+run_test() {
+    source_install "$REPO" || return 1
+
+    # --- Case 1: missing prereq -> exit 3 + remediation, no sudo ---------
+    local stub_dir
+    stub_dir="$(mktemp -d)"
+    install_failing_sudo_stub "$stub_dir"
+
+    parse_flags || return 1
+
+    # Mock the OS so the scan runs deterministically, then stub
+    # distro_pkg_installed to simulate a missing pinentry-curses.
+    OS_ID=ubuntu
+    OS_MAJOR_VERSION=24
+    distro_pkg_installed() { [[ "$1" != "pinentry-curses" ]]; }
+    # Keep rocky_repo_enabled from matter on Ubuntu dispatch.
+    rocky_repo_enabled() { return 1; }
+
+    local rc=0 out
+    out="$(
+        PATH="$stub_dir:$PATH" preflight_root_requirements 2>&1
+    )" || rc=$?
+
+    if [[ $rc -ne 3 ]]; then
+        _assert_fail "preflight_root_requirements: expected exit 3, got $rc. output: $out"
+        rm -rf "$stub_dir"
+        return 1
+    fi
+
+    assert_match "$out" "missing root-installed prerequisites" \
+        "remediation header present" || {
+        rm -rf "$stub_dir"
+        return 1
+    }
+    assert_match "$out" "pinentry-curses" \
+        "specific missing pkg named" || {
+        rm -rf "$stub_dir"
+        return 1
+    }
+    assert_match "$out" "install-prereqs.sh" \
+        "points at scripts/install-prereqs.sh" || {
+        rm -rf "$stub_dir"
+        return 1
+    }
+
+    if [[ "$out" == *"FAIL: sudo invoked"* ]]; then
+        _assert_fail "install.sh invoked sudo: $out"
+        rm -rf "$stub_dir"
+        return 1
+    fi
+
+    # --- Case 2: --skip-prereqs bypasses scan cleanly --------------------
+    parse_flags --skip-prereqs || return 1
+    rc=0
+    out="$(
+        PATH="$stub_dir:$PATH" preflight_root_requirements 2>&1
+    )" || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        _assert_fail "--skip-prereqs scan exited $rc (expected 0): $out"
+        rm -rf "$stub_dir"
+        return 1
+    fi
+    assert_match "$out" "skipping preflight_root_requirements" \
+        "--skip-prereqs log line emitted" || {
+        rm -rf "$stub_dir"
+        return 1
+    }
+
+    # --- Case 3: install.sh + lib/platform.sh contain no live sudo calls -
+    # The regression guard also lives in install.bats, but asserting it
+    # here keeps the E2E wire contract explicit.
+    if grep -nE '(^|[[:space:]])sudo[[:space:]]+[a-zA-Z]' \
+        "$REPO/install.sh" "$REPO/lib/platform.sh" |
+        grep -vE '^[^:]+:[[:digit:]]+:\s*#|printf .*sudo' >/dev/null; then
+        _assert_fail "install.sh or lib/platform.sh still contains a live sudo call"
+        rm -rf "$stub_dir"
+        return 1
+    fi
+
+    rm -rf "$stub_dir"
+}
+
+start=$(date +%s)
+failure=""
+if ! run_test; then
+    failure="assertions failed -- see stderr above"
+fi
+
+dur=$(($(date +%s) - start))
+if [[ -z "$failure" ]]; then
+    echo "E2E-15 PASS"
+    emit_junit pass "$dur"
+    exit 0
+fi
+echo "E2E-15 FAIL: $failure" >&2
+emit_junit fail "$dur" "$failure"
+exit 1

--- a/tests/unit/apt-packages.bats
+++ b/tests/unit/apt-packages.bats
@@ -141,6 +141,72 @@ LIST
     [[ "$output" == *"CALL: only-common-pkg"* ]]
 }
 
+@test "default installer (no BEGET_PKG_INSTALL) dispatches via beget_pkg_install" {
+    # Regression guard for #100: the script used to default to pkg_install
+    # which was defined in lib/platform.sh. When platform.sh stopped providing
+    # pkg_install, the default path broke silently (tests all stub the
+    # installer). This test exercises the default path by stubbing sudo
+    # instead, so we catch a recurrence.
+    stage_list minimal curl git
+    unset BEGET_PKG_INSTALL
+
+    # Intercept sudo so the "real" beget_pkg_install path runs without
+    # actually invoking apt-get/dnf.
+    local shim="$BATS_TEST_TMPDIR/sudo-shim"
+    mkdir -p "$shim"
+    cat >"$shim/sudo" <<'EOF'
+#!/usr/bin/env bash
+printf 'SUDO:'
+printf ' %s' "$@"
+printf '\n'
+EOF
+    chmod +x "$shim/sudo"
+
+    # Force the OS dispatch into the apt branch regardless of host OS.
+    local os_release="$BATS_TEST_TMPDIR/os-release"
+    printf 'ID=ubuntu\nVERSION_ID="24.04"\n' >"$os_release"
+
+    PATH="$shim:$PATH" OS_RELEASE_FILE="$os_release" \
+        BEGET_ROLE=minimal run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SUDO: apt-get install -y curl git"* ]]
+}
+
+@test "default installer on Rocky dispatches via dnf" {
+    stage_list minimal curl git
+    unset BEGET_PKG_INSTALL
+
+    local shim="$BATS_TEST_TMPDIR/sudo-shim"
+    mkdir -p "$shim"
+    cat >"$shim/sudo" <<'EOF'
+#!/usr/bin/env bash
+printf 'SUDO:'
+printf ' %s' "$@"
+printf '\n'
+EOF
+    chmod +x "$shim/sudo"
+
+    local os_release="$BATS_TEST_TMPDIR/os-release"
+    printf 'ID=rocky\nVERSION_ID="9.3"\n' >"$os_release"
+
+    PATH="$shim:$PATH" OS_RELEASE_FILE="$os_release" \
+        BEGET_ROLE=minimal run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SUDO: dnf install -y curl git"* ]]
+}
+
+@test "default installer on unsupported OS fails with a clear message" {
+    stage_list minimal curl git
+    unset BEGET_PKG_INSTALL
+
+    local os_release="$BATS_TEST_TMPDIR/os-release"
+    printf 'ID=alpine\nVERSION_ID="3.19"\n' >"$os_release"
+
+    OS_RELEASE_FILE="$os_release" BEGET_ROLE=minimal run bash "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS alpine"* ]]
+}
+
 @test "script is idempotent: two runs produce the same set of installer calls" {
     stage_list common one two
     stage_list workstation three

--- a/tests/unit/direnv.bats
+++ b/tests/unit/direnv.bats
@@ -78,11 +78,15 @@ EOF
 
 # ---- install.sh prereq list -------------------------------------------------
 
-@test "install.sh UPSTREAM_PREREQS list contains direnv (R-01)" {
-    # direnv moved from DISTRO_PREREQS to UPSTREAM_PREREQS because
-    # Rocky 9 ships it in neither base nor EPEL repos, so the upstream
-    # direnv.net installer is the only uniform cross-distro path.
-    grep -qE '^readonly UPSTREAM_PREREQS=\(.*\bdirenv\b.*\)' "$INSTALL_SH"
+@test "install.sh installs direnv via upstream (R-01)" {
+    # direnv is NOT a distro package for beget: Rocky 9 ships it in
+    # neither base nor EPEL repos, so the upstream direnv.net installer
+    # is the only uniform cross-distro path. Since issue #100 there is
+    # no longer an UPSTREAM_PREREQS array (install.sh is purely user-local
+    # and doesn't touch apt/dnf at all); the uniform-installer contract
+    # is now expressed as a direct call to install_direnv from
+    # install_user_local. Verify that contract here.
+    grep -qE '^\s*install_direnv\b' "$INSTALL_SH"
 }
 
 # ---- .envrc example quality -------------------------------------------------

--- a/tests/unit/install-prereqs.bats
+++ b/tests/unit/install-prereqs.bats
@@ -71,7 +71,9 @@ teardown() {
     # Then dnf install of the full Rocky pkg set.
     [[ "$output" == *"dnf"* ]]
     [[ "$output" == *"pinentry"* ]]
-    [[ "$output" == *"pkg-config"* ]]
+    # Rocky uses pkgconf-pkg-config (not the apt-native pkg-config name) —
+    # install.sh's rpm -q scan requires the real package name, not a Provides.
+    [[ "$output" == *"pkgconf-pkg-config"* ]]
     [[ "$output" == *"openssl-devel"* ]]
     [[ "$output" == *"gcc"* ]]
     # Ubuntu-only packages must not appear on Rocky.

--- a/tests/unit/install-prereqs.bats
+++ b/tests/unit/install-prereqs.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# tests/unit/install-prereqs.bats — unit tests for scripts/install-prereqs.sh
+#
+# Exercises the distro-dispatch logic via DRY_RUN + a synthesized
+# /etc/os-release. No real package-manager calls are made.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    PREREQS_SH="$REPO_ROOT/scripts/install-prereqs.sh"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+}
+
+teardown() {
+    reset_os_env
+}
+
+@test "install-prereqs.sh: --help prints usage and exits 0" {
+    run bash "$PREREQS_SH" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "install-prereqs.sh: unknown flag aborts non-zero" {
+    run bash "$PREREQS_SH" --bogus
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "install-prereqs.sh: reports clear error and exits 2 when not run as root" {
+    # Must not pass --dry-run here — --dry-run bypasses the root check.
+    # We invoke as the unprivileged bats runner; EUID != 0.
+    run bash "$PREREQS_SH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"must be run as root"* ]]
+    [[ "$output" == *"sudo"* ]]
+}
+
+@test "install-prereqs.sh: ubuntu --dry-run lists expected pkg set (pinentry-curses, libssl-dev, build-essential)" {
+    make_os_release "ubuntu" "24.04"
+    # Disable GNOME detection so the test is deterministic regardless of
+    # the runner's XDG_CURRENT_DESKTOP.
+    XDG_CURRENT_DESKTOP="" OS_RELEASE_FILE="$OS_RELEASE_FILE" run bash "$PREREQS_SH" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"apt-get update"* ]]
+    [[ "$output" == *"pinentry-curses"* ]]
+    [[ "$output" == *"git"* ]]
+    [[ "$output" == *"curl"* ]]
+    [[ "$output" == *"pkg-config"* ]]
+    [[ "$output" == *"libssl-dev"* ]]
+    [[ "$output" == *"build-essential"* ]]
+    # Rocky-only packages must not appear on Ubuntu.
+    [[ "$output" != *"openssl-devel"* ]]
+}
+
+@test "install-prereqs.sh: ubuntu GNOME --dry-run additionally includes pinentry-gnome3" {
+    make_os_release "ubuntu" "24.04"
+    XDG_CURRENT_DESKTOP="GNOME" OS_RELEASE_FILE="$OS_RELEASE_FILE" run bash "$PREREQS_SH" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pinentry-gnome3"* ]]
+}
+
+@test "install-prereqs.sh: rocky --dry-run enables EPEL + CRB then installs (openssl-devel, gcc)" {
+    make_os_release "rocky" "9.3"
+    XDG_CURRENT_DESKTOP="" OS_RELEASE_FILE="$OS_RELEASE_FILE" run bash "$PREREQS_SH" --dry-run
+    [ "$status" -eq 0 ]
+    # EPEL enablement comes first.
+    [[ "$output" == *"epel-release"* ]]
+    [[ "$output" == *"config-manager --set-enabled crb"* ]]
+    # Then dnf install of the full Rocky pkg set.
+    [[ "$output" == *"dnf"* ]]
+    [[ "$output" == *"pinentry"* ]]
+    [[ "$output" == *"pkg-config"* ]]
+    [[ "$output" == *"openssl-devel"* ]]
+    [[ "$output" == *"gcc"* ]]
+    # Ubuntu-only packages must not appear on Rocky.
+    [[ "$output" != *"libssl-dev"* ]]
+    [[ "$output" != *"build-essential"* ]]
+}
+
+@test "install-prereqs.sh: --dry-run bypasses root check and marks every side-effecting cmd" {
+    # Exercised as non-root (bats runner is EUID != 0). If --dry-run did
+    # NOT bypass require_root, the script would exit 2 instead of 0.
+    # If any side-effecting command leaked through --dry-run, its stdout
+    # would appear WITHOUT the `[dry-run]` prefix produced by run_cmd.
+    make_os_release "ubuntu" "24.04"
+    XDG_CURRENT_DESKTOP="" OS_RELEASE_FILE="$OS_RELEASE_FILE" \
+        run bash "$PREREQS_SH" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[dry-run] apt-get update"* ]]
+    [[ "$output" == *"[dry-run] apt-get install"* ]]
+}
+
+@test "install-prereqs.sh: unsupported OS aborts with clear message" {
+    make_os_release "arch" "rolling"
+    OS_RELEASE_FILE="$OS_RELEASE_FILE" run bash "$PREREQS_SH" --dry-run
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unsupported OS"* ]]
+    [[ "$output" == *"arch"* ]]
+}
+
+@test "install-prereqs.sh: passes shellcheck" {
+    if ! command -v shellcheck >/dev/null 2>&1; then
+        skip "shellcheck not installed"
+    fi
+    run shellcheck "$PREREQS_SH"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/install.bats
+++ b/tests/unit/install.bats
@@ -13,6 +13,7 @@ setup() {
     [[ "$output" == *"--role="* ]]
     [[ "$output" == *"--skip-secrets"* ]]
     [[ "$output" == *"--skip-apply"* ]]
+    [[ "$output" == *"--skip-prereqs"* ]]
     [[ "$output" == *"--allow-root"* ]]
     [[ "$output" == *"--help"* ]]
 }
@@ -48,13 +49,14 @@ source_install() {
     source "$INSTALL_SH"
 }
 
-@test "install.sh: parse_flags sets DRY_RUN/ROLE/SKIP_SECRETS/SKIP_APPLY/ALLOW_ROOT" {
+@test "install.sh: parse_flags sets DRY_RUN/ROLE/SKIP_SECRETS/SKIP_APPLY/SKIP_PREREQS/ALLOW_ROOT" {
     source_install
-    parse_flags --dry-run --role=minimal --skip-secrets --skip-apply --allow-root
+    parse_flags --dry-run --role=minimal --skip-secrets --skip-apply --skip-prereqs --allow-root
     [ "$DRY_RUN" -eq 1 ]
     [ "$ROLE" = "minimal" ]
     [ "$SKIP_SECRETS" -eq 1 ]
     [ "$SKIP_APPLY" -eq 1 ]
+    [ "$SKIP_PREREQS" -eq 1 ]
     [ "$ALLOW_ROOT" -eq 1 ]
 }
 
@@ -87,52 +89,122 @@ source_install() {
     [ "$status" -eq 0 ]
 }
 
-@test "install.sh: install_prereqs dry-run emits distro and upstream markers" {
+# ---- Issue #100: user-local install + preflight root-requirements -----------
+
+@test "install.sh: preflight_root_requirements: missing pinentry on ubuntu dies with exit 3 + remediation" {
     source_install
-    parse_flags --dry-run --role=minimal --skip-secrets
-    # Source the library so install_prereqs can resolve install_chezmoi /
-    # install_rbw / is_gnome. The OS dispatch never executes because
-    # DRY_RUN=1, but OS_ID is still needed for install_rbw's guard.
     # shellcheck source=/dev/null
     source "$REPO_ROOT/lib/platform.sh"
     source "$REPO_ROOT/tests/helpers/mocks.sh"
     make_os_release "ubuntu" "24.04"
     source_os_release
+    parse_flags  # defaults: SKIP_PREREQS=0
 
-    run install_prereqs
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"would pkg_install"* ]]
-    [[ "$output" == *"upstream prereqs"* ]]
-    [[ "$output" == *"chezmoi"* ]]
-    [[ "$output" == *"rbw"* ]]
+    # Simulate every distro pkg missing.
+    distro_pkg_installed() { return 1; }
+
+    run preflight_root_requirements
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"missing root-installed prerequisites"* ]]
+    [[ "$output" == *"pinentry-curses"* ]]
+    [[ "$output" == *"install-prereqs.sh"* ]]
 }
 
-@test "install.sh: install_prereqs dry-run never invokes real curl or cargo" {
+@test "install.sh: preflight_root_requirements: all distro prereqs present continues (rc=0)" {
     source_install
-    parse_flags --dry-run --role=minimal --skip-secrets
     # shellcheck source=/dev/null
     source "$REPO_ROOT/lib/platform.sh"
     source "$REPO_ROOT/tests/helpers/mocks.sh"
     make_os_release "ubuntu" "24.04"
     source_os_release
+    parse_flags
 
-    # Stub curl/cargo/sh/pkg_install to fail loudly if the dry-run branch
-    # accidentally invokes them. command -v chezmoi / rbw will already
-    # return true in the sourced test environment, so we also wipe those
-    # via a restricted PATH to force the [dry-run] branch.
-    curl() { printf 'FAIL: curl called\n' >&2; return 99; }
-    cargo() { printf 'FAIL: cargo called\n' >&2; return 99; }
-    pkg_install() { printf 'FAIL: pkg_install called\n' >&2; return 99; }
-    export -f curl cargo pkg_install
+    distro_pkg_installed() { return 0; }
 
-    # Sandbox PATH so chezmoi / rbw are NOT found — forces the install
-    # branch inside install_chezmoi / install_rbw, which should still
-    # short-circuit on DRY_RUN=1.
-    PATH="/nonexistent" run install_prereqs
+    run preflight_root_requirements
     [ "$status" -eq 0 ]
-    [[ "$output" != *"FAIL: curl called"* ]]
-    [[ "$output" != *"FAIL: cargo called"* ]]
-    [[ "$output" != *"FAIL: pkg_install called"* ]]
+    [[ "$output" == *"distro prereqs OK"* ]]
+}
+
+@test "install.sh: preflight_root_requirements: --skip-prereqs bypasses scan entirely" {
+    source_install
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/lib/platform.sh"
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+    parse_flags --skip-prereqs
+
+    # If the scan were to run it would invoke distro_pkg_installed; stub it
+    # to fail loudly so we catch any bypass regression.
+    distro_pkg_installed() { printf 'FAIL: scan ran despite --skip-prereqs\n' >&2; return 99; }
+
+    run preflight_root_requirements
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping preflight_root_requirements"* ]]
+    [[ "$output" != *"FAIL"* ]]
+}
+
+@test "install.sh: preflight_root_requirements: rocky without epel lists epel-release + crb enable" {
+    source_install
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/lib/platform.sh"
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+    make_os_release "rocky" "9.3"
+    source_os_release
+    parse_flags
+
+    # All expected pkgs present except epel-release; CRB disabled.
+    distro_pkg_installed() { [[ "$1" != "epel-release" ]]; }
+    rocky_repo_enabled() { return 1; }
+
+    run preflight_root_requirements
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"epel-release"* ]]
+    [[ "$output" == *"crb"* ]]
+    [[ "$output" == *"install-prereqs.sh"* ]]
+}
+
+@test "install.sh + lib/platform.sh: contain zero real sudo calls (regression guard)" {
+    # install.sh and lib/platform.sh must never invoke sudo themselves.
+    # The only legal occurrences are in comments and in remediation
+    # strings that tell the user to run install-prereqs.sh via sudo.
+    # Grep for a sudo command-invocation pattern: whitespace or start of
+    # line, followed by `sudo`, followed by whitespace + another word.
+    # Then filter out commented lines and printf-string instances.
+    local hits
+    hits="$(grep -nE '(^|[[:space:]])sudo[[:space:]]+[a-zA-Z]' "$REPO_ROOT/install.sh" "$REPO_ROOT/lib/platform.sh" |
+        grep -vE '^\s*#|printf .*sudo|^[^:]+:[[:digit:]]+:\s*#' || true)"
+    [[ -z "$hits" ]] || {
+        printf 'UNEXPECTED sudo calls:\n%s\n' "$hits"
+        false
+    }
+}
+
+@test "install.sh: install_user_local invokes all three upstream installers" {
+    source_install
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/lib/platform.sh"
+    source "$REPO_ROOT/tests/helpers/mocks.sh"
+    make_os_release "ubuntu" "24.04"
+    source_os_release
+    parse_flags --dry-run
+
+    # Replace the three installers with markers so we can assert
+    # they were each invoked exactly once.
+    local calls="$BATS_TEST_TMPDIR/installer-calls"
+    : >"$calls"
+    install_chezmoi() { echo chezmoi >>"$calls"; }
+    install_direnv() { echo direnv >>"$calls"; }
+    install_rbw() { echo rbw >>"$calls"; }
+    export -f install_chezmoi install_direnv install_rbw
+
+    run install_user_local
+    [ "$status" -eq 0 ]
+    run cat "$calls"
+    [[ "$output" == *"chezmoi"* ]]
+    [[ "$output" == *"direnv"* ]]
+    [[ "$output" == *"rbw"* ]]
 }
 
 # ---- Issue #98 regression tests ---------------------------------------------

--- a/tests/unit/platform.bats
+++ b/tests/unit/platform.bats
@@ -48,50 +48,6 @@ EOF
     [[ "$output" == *"cannot read os-release"* ]]
 }
 
-@test "pkg_install: no args aborts" {
-    make_os_release "ubuntu" "24.04"
-    run pkg_install
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"no packages specified"* ]]
-}
-
-@test "pkg_install: Ubuntu produces apt-get command" {
-    make_os_release "ubuntu" "24.04"
-    source_os_release
-    # Stub sudo to emit one arg per line so argv boundaries are asserted.
-    sudo() { for a in "$@"; do printf 'ARG:%s\n' "$a"; done; }
-    export -f sudo
-    run pkg_install foo bar
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"ARG:apt-get"* ]]
-    [[ "$output" == *"ARG:install"* ]]
-    [[ "$output" == *"ARG:-y"* ]]
-    [[ "$output" == *"ARG:foo"* ]]
-    [[ "$output" == *"ARG:bar"* ]]
-}
-
-@test "pkg_install: Rocky produces dnf command" {
-    make_os_release "rocky" "9.3"
-    source_os_release
-    sudo() { for a in "$@"; do printf 'ARG:%s\n' "$a"; done; }
-    export -f sudo
-    run pkg_install foo bar
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"ARG:dnf"* ]]
-    [[ "$output" == *"ARG:install"* ]]
-    [[ "$output" == *"ARG:-y"* ]]
-    [[ "$output" == *"ARG:foo"* ]]
-    [[ "$output" == *"ARG:bar"* ]]
-}
-
-@test "pkg_install: unsupported OS aborts" {
-    make_os_release "arch" "rolling"
-    source_os_release
-    run pkg_install foo
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"unsupported OS_ID: arch"* ]]
-}
-
 @test "pkg_name_pinentry_tty: Ubuntu resolves to pinentry-curses" {
     make_os_release "ubuntu" "24.04"
     source_os_release
@@ -178,120 +134,6 @@ EOF
 @test "is_gnome: returns 1 for KDE" {
     XDG_CURRENT_DESKTOP="KDE" run is_gnome
     [ "$status" -eq 1 ]
-}
-
-@test "pkg_repo_add: missing args aborts" {
-    make_os_release "ubuntu" "24.04"
-    run pkg_repo_add
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"usage"* ]]
-}
-
-@test "pkg_repo_add: Ubuntu writes .list under APT_SOURCES_DIR" {
-    make_os_release "ubuntu" "24.04"
-    source_os_release
-    export APT_SOURCES_DIR="$BATS_TEST_TMPDIR/apt"
-    mkdir -p "$APT_SOURCES_DIR"
-    # Stub curl, sudo, gpg, tee so nothing touches the system.
-    curl() { printf 'armored-key-bytes'; }
-    gpg() {
-        # Parse `gpg --dearmor -o <path>` and write a placeholder there.
-        local out=""
-        while [[ $# -gt 0 ]]; do
-            case "$1" in
-                -o) out="$2"; shift 2;;
-                *)  shift;;
-            esac
-        done
-        cat >/dev/null
-        [[ -n "$out" ]] && : >"$out"
-    }
-    tee() { cat >"$1"; }
-    sudo() { "$@"; }
-    export -f curl gpg tee sudo
-    run pkg_repo_add "https://example.com/apt stable main" \
-        "https://example.com/key.asc" "example"
-    [ "$status" -eq 0 ]
-    [ -f "$APT_SOURCES_DIR/example.list" ]
-    grep -q "signed-by=/usr/share/keyrings/example.gpg" "$APT_SOURCES_DIR/example.list"
-    grep -q "https://example.com/apt stable main" "$APT_SOURCES_DIR/example.list"
-}
-
-@test "pkg_repo_add: Ubuntu aborts when keyring fetch fails" {
-    make_os_release "ubuntu" "24.04"
-    source_os_release
-    export APT_SOURCES_DIR="$BATS_TEST_TMPDIR/apt"
-    mkdir -p "$APT_SOURCES_DIR"
-    # Stub curl to fail (simulating a 404 or network error).
-    curl() { return 22; }
-    sudo() { "$@"; }
-    export -f curl sudo
-    run pkg_repo_add "https://example.com/apt stable main" \
-        "https://example.com/key.asc" "example"
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"failed to fetch keyring"* ]]
-    [ ! -f "$APT_SOURCES_DIR/example.list" ]
-}
-
-@test "pkg_ensure_epel: noop on Ubuntu" {
-    make_os_release "ubuntu" "24.04"
-    source_os_release
-    # Fail loudly if any package-manager command is called.
-    rpm() { printf 'FAIL: rpm called\n'; return 99; }
-    sudo() { printf 'FAIL: sudo called\n'; return 99; }
-    export -f rpm sudo
-    run pkg_ensure_epel
-    [ "$status" -eq 0 ]
-    [[ "$output" != *"FAIL"* ]]
-}
-
-@test "pkg_ensure_epel: skips epel install but still enables CRB when present" {
-    make_os_release "rocky" "9.3"
-    source_os_release
-    rpm() { return 0; }   # simulate epel-release already installed
-    # Track what sudo gets called with; don't fail.
-    local calls="$BATS_TEST_TMPDIR/sudo-calls"
-    : >"$calls"
-    sudo() { printf '%s\n' "$*" >>"$calls"; return 0; }
-    export -f rpm sudo
-    run pkg_ensure_epel
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"already installed"* ]]
-    # epel-release install must NOT have been invoked; CRB enablement MUST have.
-    run cat "$calls"
-    [[ "$output" != *"install -y epel-release"* ]]
-    [[ "$output" == *"config-manager --set-enabled crb"* ]]
-}
-
-@test "pkg_ensure_epel: installs epel-release AND enables CRB when absent" {
-    make_os_release "rocky" "9.3"
-    source_os_release
-    rpm() { return 1; }   # simulate epel-release NOT installed
-    local calls="$BATS_TEST_TMPDIR/sudo-calls"
-    : >"$calls"
-    sudo() { printf '%s\n' "$*" >>"$calls"; return 0; }
-    export -f rpm sudo
-    run pkg_ensure_epel
-    [ "$status" -eq 0 ]
-    run cat "$calls"
-    [[ "$output" == *"install -y epel-release"* ]]
-    [[ "$output" == *"config-manager --set-enabled crb"* ]]
-}
-
-@test "pkg_ensure_epel: dry-run on Rocky logs intent without dnf" {
-    make_os_release "rocky" "9.3"
-    source_os_release
-    export DRY_RUN=1
-    rpm() { return 1; }   # simulate "not installed"
-    sudo() { printf 'FAIL: sudo called\n'; return 99; }
-    export -f rpm sudo
-    run pkg_ensure_epel
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"[dry-run]"* ]]
-    [[ "$output" == *"epel-release"* ]]
-    [[ "$output" == *"crb"* ]]
-    [[ "$output" != *"FAIL"* ]]
-    unset DRY_RUN
 }
 
 @test "install_chezmoi: noop when binary already on PATH" {
@@ -411,8 +253,7 @@ EOF
     PATH="$shimdir:$PATH"
 
     cargo() { printf 'FAIL: cargo called\n'; return 99; }
-    pkg_install() { printf 'FAIL: pkg_install called\n'; return 99; }
-    export -f cargo pkg_install
+    export -f cargo
 
     run install_rbw
     [ "$status" -eq 0 ]
@@ -420,7 +261,11 @@ EOF
     [[ "$output" != *"FAIL"* ]]
 }
 
-@test "install_rbw: dry-run logs Ubuntu build deps without invoking cargo or curl" {
+@test "install_rbw: dry-run logs rustup + cargo install intent without invoking them" {
+    # install_rbw no longer installs build deps itself — those come from
+    # scripts/install-prereqs.sh and are verified by install.sh's
+    # preflight_root_requirements scan. The dry-run path should only log
+    # the user-local steps (rustup + cargo install).
     make_os_release "ubuntu" "24.04"
     source_os_release
     local saved_path="$PATH"
@@ -428,42 +273,20 @@ EOF
     export DRY_RUN=1
 
     cargo() { printf 'FAIL: cargo called\n'; return 99; }
-    pkg_install() { printf 'FAIL: pkg_install called\n'; return 99; }
     curl() { printf 'FAIL: curl called\n'; return 99; }
-    export -f cargo pkg_install curl
+    export -f cargo curl
 
     run install_rbw
     PATH="$saved_path"
     [ "$status" -eq 0 ]
     [[ "$output" == *"[dry-run]"* ]]
-    [[ "$output" == *"libssl-dev"* ]]
-    [[ "$output" == *"build-essential"* ]]
     [[ "$output" == *"rust toolchain via rustup"* ]]
     [[ "$output" == *"cargo install rbw"* ]]
-    [[ "$output" != *"FAIL"* ]]
-    unset DRY_RUN
-}
-
-@test "install_rbw: dry-run logs Rocky build deps (dnf-flavored package names)" {
-    make_os_release "rocky" "9.3"
-    source_os_release
-    local saved_path="$PATH"
-    PATH="/nonexistent"
-    export DRY_RUN=1
-
-    cargo() { printf 'FAIL: cargo called\n'; return 99; }
-    pkg_install() { printf 'FAIL: pkg_install called\n'; return 99; }
-    curl() { printf 'FAIL: curl called\n'; return 99; }
-    export -f cargo pkg_install curl
-
-    run install_rbw
-    PATH="$saved_path"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"openssl-devel"* ]]
-    [[ "$output" == *"gcc"* ]]
-    # Ubuntu-specific packages must NOT appear on Rocky.
+    # Build deps must NOT appear — they're not our concern anymore.
     [[ "$output" != *"libssl-dev"* ]]
     [[ "$output" != *"build-essential"* ]]
+    [[ "$output" != *"openssl-devel"* ]]
+    [[ "$output" != *"FAIL"* ]]
     unset DRY_RUN
 }
 
@@ -534,28 +357,3 @@ EOF
     [[ "$output" == *"failed to fetch rustup installer"* ]]
 }
 
-@test "pkg_repo_add: Rocky writes .repo under YUM_REPOS_DIR" {
-    make_os_release "rocky" "9.3"
-    source_os_release
-    export YUM_REPOS_DIR="$BATS_TEST_TMPDIR/yum"
-    mkdir -p "$YUM_REPOS_DIR"
-    # Stub curl to write the target path (-o path url), sudo to passthru, rpm to noop.
-    curl() {
-        local out=""
-        while [[ $# -gt 0 ]]; do
-            case "$1" in
-                -o) out="$2"; shift 2;;
-                *)  shift;;
-            esac
-        done
-        printf '[example]\nname=example\nbaseurl=https://example.com/rocky/9\n' >"$out"
-    }
-    rpm() { :; }
-    sudo() { "$@"; }
-    export -f curl rpm sudo
-    run pkg_repo_add "https://example.com/example.repo" \
-        "https://example.com/RPM-GPG-KEY-example" "example"
-    [ "$status" -eq 0 ]
-    [ -f "$YUM_REPOS_DIR/example.repo" ]
-    grep -q "baseurl=https://example.com/rocky/9" "$YUM_REPOS_DIR/example.repo"
-}


### PR DESCRIPTION
## Summary

- `install.sh` + `lib/platform.sh` are now guaranteed zero-sudo. The one-liner is honest about not needing root, fixing the silent-hang that surfaced in containers without passwordless sudo after #98.
- All root-requiring distro packages move to `scripts/install-prereqs.sh`, which users run explicitly in step 1 of the new two-step bootstrap.
- `install.sh` gains `preflight_root_requirements()`: a read-only scan that exits **3** with copy-pasteable remediation when anything is missing. `--skip-prereqs` bypasses it for CI/automation paths.

## Changes

- `install.sh`: added `preflight_root_requirements`, `install_user_local`, `expected_distro_pkgs`, `distro_pkg_installed`, `rocky_repo_enabled`, `--skip-prereqs` flag; removed all sudo calls
- `lib/platform.sh`: stripped sudo; `pkg_install` + `pkg_repo_add` deleted (library is now sudo-free by design, documented at lines 8–11)
- `scripts/install-prereqs.sh` (new): sudo-requiring prereq installer — pinentry, pkg-config, libssl-dev/openssl-devel, build-essential/gcc, `pinentry-gnome3` under GNOME, EPEL + CRB on Rocky
- `run_onchange_before_20-packages-common.sh`: self-contained `beget_pkg_install` (inline apt/dnf dispatch using `BEGET_SUDO`) — mirrors `run_onchange_before_10`'s pattern; no longer depends on `lib/platform.sh`
- `tests/e2e/Dockerfile.{ubuntu24,rocky9}`: bake prereqs via `bash scripts/install-prereqs.sh` at build time (doubles as a smoke test of the script)
- `tests/e2e/e2e-15-missing-prereqs-fail-fast.sh` (new): E2E for exit 3 + remediation, `--skip-prereqs` bypass, static no-sudo grep guard
- `tests/e2e/e2e-01/02/03/05-*.sh`: rewritten to use the new function seams (`preflight_root_requirements`, `install_user_local`, `expected_distro_pkgs`) instead of the removed `install_prereqs`
- `tests/unit/install-prereqs.bats` (new): unit coverage for `scripts/install-prereqs.sh`
- `tests/unit/apt-packages.bats`: 3 new regression tests exercising the default `beget_pkg_install` path (Ubuntu dispatch, Rocky dispatch, unsupported-OS fail-fast) — closes the test gap that hid the pre-existing `pkg_install` dependency
- `tests/unit/install.bats`: coverage for `preflight_root_requirements`, `--skip-prereqs`, static no-sudo guard
- `tests/unit/direnv.bats`, `tests/unit/platform.bats`: updated to the new function surface
- `scripts/ci/run-smoke-canary.sh`: comment block accurately describes the two-step flow post-#100
- `README.md`: two-step install section replacing the old "Phase 1 target" placeholder
- `docs/runbook.md`: §1 Fresh Machine Bootstrap two-step commands + accurate expected output; §6 Offline Operation step 1; new Troubleshooting §"Missing prereqs — fresh machine"

## Linked Issues

Closes #100

## Test Plan

- `scripts/ci/run-lint.sh` → exit 0 (shellcheck across install.sh, lib/platform.sh, all run_onchange scripts)
- `scripts/ci/run-integration.sh` → exit 0 (shellcheck, shfmt, chezmoi-render, header-comments, make-targets)
- `tests/bats/bin/bats tests/unit` → 251/251 pass
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` → 0 findings
- E2E-15 verified during development: exit 3 + remediation on missing pinentry, `--skip-prereqs` bypass, static sudo-grep guard
- Static invariant (also asserted by install.bats): `install.sh` + `lib/platform.sh` contain no live `sudo` invocations, only commented/printf strings