### PR TITLE
fix(chezmoi): gate apt-repos/dnf-repos by OS family via .chezmoiignore.tmpl

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -1,0 +1,16 @@
+{{- /*
+  Per-host file filter. chezmoi renders this template against the target
+  host's environment, then ignores whichever files the rendered output
+  lists. Used here to gate the two repo-registration scripts by OS
+  family — they are not themselves templated, so without this filter
+  chezmoi would run apt-repos on a dnf host (and vice versa).
+*/ -}}
+{{- $id := .chezmoi.osRelease.id -}}
+{{- $isDebianFamily := or (eq $id "ubuntu") (eq $id "debian") (eq $id "linuxmint") (eq $id "pop") -}}
+{{- $isRhelFamily := or (eq $id "rhel") (eq $id "rocky") (eq $id "centos") (eq $id "almalinux") (eq $id "fedora") -}}
+{{- if not $isDebianFamily }}
+run_onchange_before_10-apt-repos.sh
+{{- end }}
+{{- if not $isRhelFamily }}
+run_onchange_before_10-dnf-repos.sh
+{{- end }}

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-unit: bootstrap-test-deps
 	@mkdir -p tests/results
 	tests/bats/bin/bats --report-formatter junit --output tests/results tests/unit
 
-# ---- Integration tests (IT-01, IT-02, IT-03, IT-08, IT-09) ------------------
+# ---- Integration tests (IT-01, IT-02, IT-03, IT-08, IT-09, IT-10) -----------
 # Runs each tests/integration/*.sh in turn. A failure in any one stops the
 # tier with a non-zero exit so CI surfaces the first offender clearly.
 test-integration:
@@ -74,7 +74,7 @@ test-integration:
 	mkdir -p tests/results; \
 	for s in tests/integration/shellcheck.sh tests/integration/shfmt.sh \
 	          tests/integration/chezmoi-render.sh tests/integration/header-comments.sh \
-	          tests/integration/make-targets.sh; do \
+	          tests/integration/make-targets.sh tests/integration/chezmoiignore-dispatch.sh; do \
 	    if [[ ! -x "$$s" ]]; then echo "MISSING: $$s" >&2; exit 1; fi; \
 	    echo "==> $$s"; \
 	    "$$s"; \

--- a/scripts/ci/run-integration.sh
+++ b/scripts/ci/run-integration.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# scripts/ci/run-integration.sh — integration test tier (IT-01, IT-02, IT-03, IT-09).
+# scripts/ci/run-integration.sh — integration test tier (IT-01, IT-02, IT-03,
+# IT-08, IT-09, IT-10).
 #
 # Delegates to `make test-integration`, which runs each tests/integration/*.sh
 # in order: shellcheck.sh (IT-01), shfmt.sh (IT-02), chezmoi-render.sh (IT-03),
-# header-comments.sh (IT-09). A failure in any one fails this job.
+# header-comments.sh (IT-09), make-targets.sh (IT-08), chezmoiignore-dispatch.sh
+# (IT-10). A failure in any one fails this job.
 set -euo pipefail
 
 make test-integration

--- a/tests/integration/chezmoiignore-dispatch.sh
+++ b/tests/integration/chezmoiignore-dispatch.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# tests/integration/chezmoiignore-dispatch.sh -- IT-10.
+#
+# Verify .chezmoiignore.tmpl gates the OS-specific repo-registration
+# scripts correctly. chezmoi reads /etc/os-release at render time from
+# the host, so cross-OS verification requires either Docker or a source
+# substitution; this test does the latter for speed — substitutes the
+# real osRelease.id reference with literal distro ids, then renders.
+#
+# Checks the actual .chezmoiignore.tmpl file, so a future edit that
+# breaks the contract will be caught here before CI even reaches the
+# E2E canary that first surfaced the dispatch bug.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMPL="$REPO_ROOT/.chezmoiignore.tmpl"
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+    echo "chezmoiignore-dispatch: chezmoi not installed" >&2
+    exit 2
+fi
+
+if [[ ! -f "$TMPL" ]]; then
+    echo "chezmoiignore-dispatch: $TMPL not found" >&2
+    exit 2
+fi
+
+# Baseline: the real template renders on the host without errors. IT-03
+# covers this for every *.tmpl; repeated here for clear provenance.
+chezmoi execute-template <"$TMPL" >/dev/null
+
+# Swap `.chezmoi.osRelease.id` for a literal and render. Returns the
+# resulting ignore list on stdout.
+render_for_id() {
+    local id="$1"
+    sed "s|\.chezmoi\.osRelease\.id|\"$id\"|g" "$TMPL" |
+        chezmoi execute-template
+}
+
+fail=0
+report_fail() {
+    echo "FAIL: $1" >&2
+    fail=1
+}
+
+assert_ignored() {
+    local out="$1" file="$2" msg="$3"
+    if [[ "$out" != *"$file"* ]]; then
+        report_fail "$msg — expected '$file' in ignore list"
+        printf '%s\n' "$out" | sed 's/^/    /' >&2
+    fi
+}
+
+assert_not_ignored() {
+    local out="$1" file="$2" msg="$3"
+    if [[ "$out" == *"$file"* ]]; then
+        report_fail "$msg — did not expect '$file' in ignore list"
+        printf '%s\n' "$out" | sed 's/^/    /' >&2
+    fi
+}
+
+# Debian family: dnf-repos is ignored, apt-repos runs.
+for id in ubuntu debian linuxmint pop; do
+    out=$(render_for_id "$id")
+    assert_not_ignored "$out" "apt-repos" "$id"
+    assert_ignored "$out" "dnf-repos" "$id"
+done
+
+# RHEL family: apt-repos is ignored, dnf-repos runs.
+for id in rhel rocky centos almalinux fedora; do
+    out=$(render_for_id "$id")
+    assert_ignored "$out" "apt-repos" "$id"
+    assert_not_ignored "$out" "dnf-repos" "$id"
+done
+
+# Unsupported distro: both ignored — neither apt nor dnf is usable.
+out=$(render_for_id "arch")
+assert_ignored "$out" "apt-repos" "arch"
+assert_ignored "$out" "dnf-repos" "arch"
+
+if [[ $fail -eq 1 ]]; then
+    echo "chezmoiignore-dispatch: one or more assertions failed" >&2
+    exit 1
+fi
+
+echo "chezmoiignore-dispatch: OK"


### PR DESCRIPTION
## Summary

`run_onchange_before_10-apt-repos.sh` and `-dnf-repos.sh` are not themselves templated, so chezmoi ran them on every host. The smoke canary caught this when apt-repos exited with `sudo: apt-get: command not found` on Rocky9. Symmetric bug exists for dnf-repos on Ubuntu but was masked because apt-repos failed first.

Fix: add `.chezmoiignore.tmpl`, rendered per-host — Debian-family ignores dnf-repos, RHEL-family ignores apt-repos, unsupported distros ignore both (fail-safe).

## Changes

- **`.chezmoiignore.tmpl`** (new) — per-host filter; covers ubuntu/debian/linuxmint/pop as Debian family and rhel/rocky/centos/almalinux/fedora as RHEL family.
- **`tests/integration/chezmoiignore-dispatch.sh`** (new, IT-10) — sed-substitutes `.chezmoi.osRelease.id` with synthetic ids and asserts the right ignore list for 10 distros. Tests the actual `.chezmoiignore.tmpl` file, not a copy.
- **`Makefile`** — wires IT-10 into `test-integration`; updates IT-numbering comment.
- **`scripts/ci/run-integration.sh`** — header comment updated.

## Linked Issues

Closes #97

## Test Plan

- [x] `./scripts/ci/run-lint.sh` — clean
- [x] `./scripts/ci/run-unit.sh` — 251/251 pass
- [x] `./scripts/ci/run-integration.sh` — 6/6 pass (including new IT-10)
- [x] `trivy fs --severity HIGH,CRITICAL` — zero findings
- [x] Manual: `chezmoi execute-template < .chezmoiignore.tmpl` inside a real rocky9 docker container returns exactly `run_onchange_before_10-apt-repos.sh` (the one expected entry)
- [ ] CI green on PR (e2e-ubuntu + e2e-rocky must both pass — these do not exercise `chezmoi apply` end-to-end, so they won't directly exercise the fix; follow-up filed to add that coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)